### PR TITLE
Apply PEP8 style guide

### DIFF
--- a/.travis-flake8-script.sh
+++ b/.travis-flake8-script.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script is meant to be called by the "install" step defined in
+# .travis.yml.
+
+# Install PyRDF
+python setup.py install --user
+
+# Run flake8
+flake8 --config=flake8.cfg

--- a/.travis-flake8-script.sh
+++ b/.travis-flake8-script.sh
@@ -7,4 +7,5 @@
 python setup.py install --user
 
 # Run flake8
+flake8 --version
 flake8 --config=flake8.cfg

--- a/.travis-unit-script.sh
+++ b/.travis-unit-script.sh
@@ -16,6 +16,9 @@ check_error()
     fi
 }
 
+# Install PyRDF
+python setup.py install --user 
+
 # Run tests
 # -x exit instantly on first error or failed test
 # -v increase verbosity

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-# adapted from https://github.com/astrofrog/example-travis-conda/blob/master/.travis.yml
 language: python
 
 matrix:
@@ -36,6 +35,7 @@ install:
 
   - conda env create -f conda-python-$TRAVIS_PYTHON_VERSION-test-env.yaml -n test
   - source activate test
+  - conda install -q --yes flake8
 
 script:
   - bash .travis-$TEST_SUITE-script.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,17 @@ matrix:
     # Here you can add or remove specific builds, and Python versions. You
     # should currently be able to use Python 2.6, 2.7, or 3.3 or later.
 
-    - python: 2.7.15
+    - stage: 'style checks'
+      python: '2.7.15'
+      language: python
+      env: TEST_SUITE=flake8
+    - stage: 'unit tests'
+      python: 2.7.15
+      env: TEST_SUITE=unit
 
-    #- python: 2.7
-    #  env: NUMPY=1.8 SCIPY=0.14
+stages:
+  - 'style checks'
+  - 'unit tests'
 
 before_install:
 
@@ -31,6 +38,4 @@ install:
   - source activate test
 
 script:
-
-  - python setup.py install --user # install PyRDF
-  - bash .travis-script.sh  # will run all tests in the package
+  - bash .travis-$TEST_SUITE-script.sh

--- a/PyRDF/CallableGenerator.py
+++ b/PyRDF/CallableGenerator.py
@@ -1,7 +1,6 @@
 class CallableGenerator(object):
     """
-    Class that generates a callable
-    to parse a PyRDF graph.
+    Class that generates a callable to parse a PyRDF graph.
 
     Attributes
     ----------
@@ -9,6 +8,7 @@ class CallableGenerator(object):
         Head node of a PyRDF graph.
 
     """
+
     def __init__(self, head_node):
         """
         Creates a new `CallableGenerator`.
@@ -23,8 +23,7 @@ class CallableGenerator(object):
 
     def get_action_nodes(self, node_py=None):
         """
-        Recurses through PyRDF graph and collects
-        the PyRDF node objects.
+        Recurses through PyRDF graph and collects the PyRDF node objects.
 
         Parameters
         ----------
@@ -61,8 +60,7 @@ class CallableGenerator(object):
 
     def get_callable(self):
         """
-        Converts a given graph into
-        a callable and returns the same.
+        Converts a given graph into a callable and returns the same.
 
         Returns
         -------
@@ -73,15 +71,13 @@ class CallableGenerator(object):
             recursively.
 
         """
-
         # Prune the graph to check user references
         self.head_node.graph_prune()
 
         def mapper(node_cpp, node_py=None):
             """
-            The callable that recurses through
-            the PyRDF nodes and executes operations
-            from a starting (PyROOT) RDF node.
+            The callable that recurses through the PyRDF nodes and executes
+            operations from a starting (PyROOT) RDF node.
 
             Parameters
             ----------
@@ -100,7 +96,6 @@ class CallableGenerator(object):
                 of their corresponding actions in the graph.
 
             """
-
             return_vals = []
 
             parent_node = node_cpp
@@ -109,9 +104,11 @@ class CallableGenerator(object):
                 # current PyRDF node as the head node
                 node_py = self.head_node
             else:
-                # Execute the current operation using the output of the parent node (node_cpp)
+                # Execute the current operation using the output of the parent
+                # node (node_cpp)
                 RDFOperation = getattr(node_cpp, node_py.operation.name)
-                pyroot_node = RDFOperation(*node_py.operation.args, **node_py.operation.kwargs)
+                operation = node_py.operation
+                pyroot_node = RDFOperation(*operation.args, **operation.kwargs)
                 # The result is a pyroot object which is stored together with
                 # the pyrdf node. This binds the pyroot object lifetime to the
                 # pyrdf node, so both nodes will be kept alive as long as there

--- a/PyRDF/Node.py
+++ b/PyRDF/Node.py
@@ -1,14 +1,14 @@
 from __future__ import print_function
 from .Operation import Operation
 from .Proxy import Proxy
-import sys, gc
+import gc
+
 
 class Node(object):
     """
-    A Class that represents a node in RDataFrame
-    operations graph. A Node houses an operation
-    and has references to children nodes. For details
-    on the types of operations supported, try :
+    A Class that represents a node in RDataFrame operations graph. A Node houses
+    an operation and has references to children nodes. For details on the types
+    of operations supported, try :
 
     import PyRDF
     PyRDF.use(...) # Choose your backend
@@ -40,6 +40,7 @@ class Node(object):
         functionality of this node on the cpp side.
 
     """
+
     def __init__(self, get_head, operation):
         """
         Creates a new `Node` based on the 'operation'.
@@ -57,13 +58,13 @@ class Node(object):
         """
         if get_head is None:
             # Function to get 'head' Node
-            self.get_head = lambda : self
+            self.get_head = lambda: self
         else:
             self.get_head = get_head
 
         self.operation = operation
         self.children = []
-        self._cur_attr = "" # Name of the new incoming operation
+        self._cur_attr = ""  # Name of the new incoming operation
         self.value = None
         self.pyroot_node = None
 
@@ -79,7 +80,7 @@ class Node(object):
             that represent the current PyRDF node.
 
         """
-        state_dict = {'children':self.children}
+        state_dict = {'children': self.children}
         if self.operation:
             state_dict['operation_name'] = self.operation.name
             state_dict['operation_args'] = self.operation.args
@@ -101,7 +102,9 @@ class Node(object):
         """
         self.children = state['children']
         if state.get('operation_name'):
-            self.operation = Operation(state['operation_name'], *state['operation_args'], **state["operation_kwargs"])
+            self.operation = Operation(state['operation_name'],
+                                       *state['operation_args'],
+                                       **state["operation_kwargs"])
         else:
             self.operation = None
 
@@ -123,8 +126,7 @@ class Node(object):
             current node.
 
         """
-
-        self._cur_attr = attr # Stores new operation name
+        self._cur_attr = attr  # Stores new operation name
 
         # Check if the current call is a dunder method call
         import re
@@ -162,9 +164,10 @@ class Node(object):
 
     def graph_prune(self):
         """
-        Prunes nodes from the current PyRDF graph under certain conditions. The current
-        node will be pruned if it has no children and the user application does not hold
-        any reference to it. The children of the current node will get recursively pruned.
+        Prunes nodes from the current PyRDF graph under certain conditions.
+        The current node will be pruned if it has no children and the user
+        application does not hold any reference to it. The children of the
+        current node will get recursively pruned.
 
         Returns
         -------

--- a/PyRDF/Node.py
+++ b/PyRDF/Node.py
@@ -162,35 +162,6 @@ class Node(object):
 
         return newNode
 
-    def _is_prunable(self):
-        # Condition 1 - Not enough references
-
-        # If the number of referrers to the current node is
-        # less than 4, then the node has to be pruned.
-
-        # The 3 referrers to the current node would be :
-        # - The current function (graph_prune())
-        # - An internal reference (which every Python object has)
-        # - The current node's parent node
-        #
-        # (If the user had a variable reference to the current node,
-        # the value would be at least 4. Hence nodes with less than
-        # 4 references will have to be removed)
-
-        # NOTE :- sys.getrefcount(node) gives a way higher value
-        # and hence doesn't work in this case
-        if len(gc.get_referrers(self)) <= 3:
-            return True
-
-        # Condition 2 - Action value already computed
-
-        # If the current node's value was already computed, it should get
-        # pruned only if it's an action node.
-        if self.operation and self.operation.is_action() and self.value:
-            return True
-
-        return False
-
     def graph_prune(self):
         """
         Prunes nodes from the current PyRDF graph under certain conditions.
@@ -214,6 +185,31 @@ class Node(object):
         self.children = children
 
         if not self.children:
-            return self._is_prunable()
+            # Every pruning condition is written on
+            # a separate line
+            if len(gc.get_referrers(self)) <= 3 or \
+               (self.operation and self.operation.is_action() and self.value):
+
+                # ***** Condition 1 *****
+                # If the number of referrers to the current node is
+                # less than 4, then the node has to be pruned.
+
+                # The 3 referrers to the current node would be :
+                # - The current function (graph_prune())
+                # - An internal reference (which every Python object has)
+                # - The current node's parent node
+                #
+                # [If the user had a variable reference to the current node,
+                # the value would be at least 4. Hence nodes with less than
+                # 4 references will have to be removed ]
+
+                # NOTE :- sys.getrefcount(node) gives a way higher value and
+                # hence doesn't work in this case
+
+                # ***** Condition 2 *****
+                # If the current node's value was already
+                # computed, it should get pruned only if it's
+                # an action node.
+                return True
 
         return False

--- a/PyRDF/Operation.py
+++ b/PyRDF/Operation.py
@@ -1,10 +1,11 @@
 from __future__ import print_function
 from enum import Enum
 
+
 class Operation(object):
     """
-    A Generic representation of an operation. The
-    operation could be a transformation or an action.
+    A Generic representation of an operation. The operation could be a
+    transformation or an action.
 
     Attributes
     ----------
@@ -71,28 +72,28 @@ class Operation(object):
         ops = Operation.Types
 
         operations_dict = {
-        'Define':ops.TRANSFORMATION,
-        'Filter':ops.TRANSFORMATION,
-        'Range':ops.TRANSFORMATION,
-        'Aggregate':ops.ACTION,
-        'Histo1D':ops.ACTION,
-        'Histo2D':ops.ACTION,
-        'Histo3D':ops.ACTION,
-        'Profile1D':ops.ACTION,
-        'Profile2D':ops.ACTION,
-        'Profile3D':ops.ACTION,
-        'Count':ops.ACTION,
-        'Min':ops.ACTION,
-        'Max':ops.ACTION,
-        'Mean':ops.ACTION,
-        'Sum':ops.ACTION,
-        'Fill':ops.ACTION,
-        'Reduce':ops.ACTION,
-        'Report':ops.ACTION,
-        'Take':ops.ACTION,
-        'Graph':ops.ACTION,
-        'Snapshot':ops.INSTANT_ACTION,
-        'Foreach':ops.INSTANT_ACTION
+            'Define': ops.TRANSFORMATION,
+            'Filter': ops.TRANSFORMATION,
+            'Range': ops.TRANSFORMATION,
+            'Aggregate': ops.ACTION,
+            'Histo1D': ops.ACTION,
+            'Histo2D': ops.ACTION,
+            'Histo3D': ops.ACTION,
+            'Profile1D': ops.ACTION,
+            'Profile2D': ops.ACTION,
+            'Profile3D': ops.ACTION,
+            'Count': ops.ACTION,
+            'Min': ops.ACTION,
+            'Max': ops.ACTION,
+            'Mean': ops.ACTION,
+            'Sum': ops.ACTION,
+            'Fill': ops.ACTION,
+            'Reduce': ops.ACTION,
+            'Report': ops.ACTION,
+            'Take': ops.ACTION,
+            'Graph': ops.ACTION,
+            'Snapshot': ops.INSTANT_ACTION,
+            'Foreach': ops.INSTANT_ACTION
         }
 
         op_type = operations_dict.get(name)

--- a/PyRDF/Proxy.py
+++ b/PyRDF/Proxy.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 from .CallableGenerator import CallableGenerator
 
+
 class Proxy(object):
     """
     Instances of Proxy act as futures of the result produced
@@ -19,6 +20,7 @@ class Proxy(object):
         instance wraps.
 
     """
+
     def __init__(self, action_node):
         """
         Creates a new `Proxy` object for a
@@ -45,10 +47,9 @@ class Proxy(object):
             current action node.
 
         """
-
-        self._cur_attr = attr # Stores the name of operation call
+        self._cur_attr = attr  # Stores the name of operation call
         return self._call_handler
-    
+
     def GetValue(self):
         """
         Returns the result value of the current action
@@ -63,7 +64,7 @@ class Proxy(object):
             current action node in the computational graph.
 
         """
-        if not self.action_node.value: # If event-loop not triggered
+        if not self.action_node.value:  # If event-loop not triggered
             from . import current_backend
             generator = CallableGenerator(self.action_node.get_head())
             current_backend.execute(generator)
@@ -73,5 +74,4 @@ class Proxy(object):
     def _call_handler(self, *args, **kwargs):
         # Handles an operation call to the current action node
         # and returns result of the current action node.
-
         return getattr(self.GetValue(), self._cur_attr)(*args, **kwargs)

--- a/PyRDF/RDataFrame.py
+++ b/PyRDF/RDataFrame.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from .Node import Node
 import ROOT
 
+
 class RDataFrame(Node):
     """
     The Python equivalent of ROOT C++'s
@@ -15,10 +16,14 @@ class RDataFrame(Node):
 
     Supported constructor arguments
     -------------------------------
-    PyRDF's RDataFrame constructor accepts the same arguments as the ROOT's RDataFrame
-    constructor (see https://root.cern/doc/master/classROOT_1_1RDataFrame.html). In addition,
-    PyRDF allows you to use Python lists in place of C++ vectors as arguments of the constructor,
-    e.g., `RDataFrame("myTree", ["file1.root", "file2.root"]`.
+    PyRDF's RDataFrame constructor accepts the same arguments as the ROOT's
+    RDataFrame constructor
+    (see https://root.cern/doc/master/classROOT_1_1RDataFrame.html).
+
+    In addition, PyRDF allows you to use Python lists in place of C++ vectors as
+    arguments of the constructor, example:
+
+    RDataFrame("myTree", ["file1.root", "file2.root"]
 
     Raises
     ------
@@ -30,8 +35,7 @@ class RDataFrame(Node):
 
     def __init__(self, *args):
         """
-        Creates a new RDataFrame instance for
-        the given arguments.
+        Creates a new RDataFrame instance for the given arguments.
 
         Parameters
         ----------
@@ -40,10 +44,9 @@ class RDataFrame(Node):
             the RDataFrame object.
 
         """
-
         super(RDataFrame, self).__init__(None, None)
 
-        args = list(args) # Make args mutable
+        args = list(args)  # Make args mutable
         num_params = len(args)
 
         for i in range(num_params):
@@ -52,9 +55,10 @@ class RDataFrame(Node):
                 args[i] = self._get_vector_from_list(args[i])
 
         try:
-            ROOT.ROOT.RDataFrame(*args) # Check if the args are correct
+            ROOT.ROOT.RDataFrame(*args)  # Check if the args are correct
         except TypeError as e:
-            rdf_exception = RDataFrameException(e, "Error creating the RDataFrame !")
+            msg = "Error creating the RDataFrame !"
+            rdf_exception = RDataFrameException(e, msg)
             rdf_exception.__cause__ = None
             # The above line is to supress the traceback of error 'e'
             raise rdf_exception
@@ -62,23 +66,22 @@ class RDataFrame(Node):
         self.args = args
 
     def get_branches(self):
-        # RDataFrame(TTree& tree, const vector<string>& defaultBranches = {})
+        """Gets list of default branches if passed by the user."""
+        # ROOT Constructor:
+        # RDataFrame(TTree& tree, defaultBranches = {})
         if len(self.args) == 2 and isinstance(self.args[0], ROOT.TTree):
             return self.args[1]
-        # RDataFrame(treeName, filenameglob, const vector<string>& defaultBranches = {})
-        # RDataFrame(treename, filenames, const vector<string>& defaultBranches = {})
-        # RDataFrame(treeName, dirPtr, const vector<string>& defaultBranches = {})
+        # ROOT Constructors:
+        # RDataFrame(treeName, filenameglob, defaultBranches = {})
+        # RDataFrame(treename, filenames, defaultBranches = {})
+        # RDataFrame(treeName, dirPtr, defaultBranches = {})
         if len(self.args) == 3:
             return self.args[2]
 
         return None
 
     def _get_vector_from_list(self, arg):
-        """
-        Converts a python list of strings
-        to a vector.
-
-        """
+        """Converts a python list of strings to a vector."""
         reqd_vec = ROOT.std.vector('string')()
 
         for elem in arg:
@@ -88,14 +91,12 @@ class RDataFrame(Node):
 
     def get_num_entries(self):
         """
-        Gets the number of entries in
-        the given dataset.
+        Gets the number of entries in the given dataset.
 
         Returns
         -------
         int
-            This is the computed number of entries
-            in the input dataset.
+            This is the computed number of entries in the input dataset.
 
         """
         first_arg = self.args[0]
@@ -125,7 +126,7 @@ class RDataFrame(Node):
 
     def get_treename(self):
         """
-        Get name of the TTree
+        Get name of the TTree.
 
         Returns
         -------
@@ -133,7 +134,7 @@ class RDataFrame(Node):
             Name of the TTree, or None if there is no tree.
 
         """
-        first_arg =  self.args[0]
+        first_arg = self.args[0]
         if isinstance(first_arg, ROOT.TChain):
             # Get name from a given TChain
             return first_arg.GetName()
@@ -148,7 +149,7 @@ class RDataFrame(Node):
 
     def get_inputfiles(self):
         """
-        Get list of input files
+        Get list of input files.
 
         This list can be extracted from a given TChain or from the list of
         arguments.
@@ -164,22 +165,26 @@ class RDataFrame(Node):
         if isinstance(first_arg, ROOT.TChain):
             # Extract file names from a given TChain
             chain = first_arg
-            return [chainElem.GetTitle() for chainElem in chain.GetListOfFiles()]
+            return [chainElem.GetTitle()
+                    for chainElem in chain.GetListOfFiles()]
         if len(self.args) > 1:
             second_arg = self.args[1]
-            if isinstance(second_arg, str) or isinstance(second_arg, ROOT.std.vector('string')):
-                # Get file(s) from second argument (may contain globbing characters)
+            if (isinstance(second_arg, str) or
+               isinstance(second_arg, ROOT.std.vector('string'))):
+                # Get file(s) from second argument
+                # (may contain globbing characters)
                 return second_arg
         # RDataFrame may have been created with no input files
         return None
 
+
 class RDataFrameException(Exception):
     """
-    A special type of Exception
-    that shows up for incorrect
-    arguments to RDataFrame.
+    A special type of Exception that shows up for incorrect arguments to
+    RDataFrame.
 
     """
+
     def __init__(self, exception, msg):
         """
         Creates a new `RDataFrameException`.

--- a/PyRDF/__init__.py
+++ b/PyRDF/__init__.py
@@ -1,3 +1,6 @@
+from .RDataFrame import RDataFrame  # noqa
+from .RDataFrame import RDataFrameException  # noqa
+from .CallableGenerator import CallableGenerator  # noqa
 from backend.Local import Local
 from backend.Backend import Backend
 

--- a/PyRDF/__init__.py
+++ b/PyRDF/__init__.py
@@ -61,13 +61,14 @@ def include(includes_list):
 
     includes.extend(includes_list)
 
+
 def initialize(fun, *args, **kwargs):
     """
     Set a function that will be executed as a first step on every backend before
     any other operation.
 
-    This allows users to inject and execute custom code on the worker environment
-    without being part of the RDataFrame computational graph.
+    This allows users to inject and execute custom code on the worker
+    environment without being part of the RDataFrame computational graph.
 
     Parameters
     ----------

--- a/PyRDF/__init__.py
+++ b/PyRDF/__init__.py
@@ -1,12 +1,11 @@
-from .RDataFrame import RDataFrame, RDataFrameException
-from .CallableGenerator import CallableGenerator
 from backend.Local import Local
 from backend.Backend import Backend
 
 current_backend = Local()
 includes = []
 
-def use(backend_name, conf = {}):
+
+def use(backend_name, conf={}):
     """
     Allows the user to choose the execution backend.
 
@@ -22,25 +21,27 @@ def use(backend_name, conf = {}):
 
     """
     future_backends = [
-    "dask"
+        "dask"
     ]
 
     global current_backend
 
     if backend_name in future_backends:
-        raise NotImplementedError(" This backend environment will be considered in the future !")
+        msg = " This backend environment will be considered in the future !"
+        raise NotImplementedError(msg)
     elif backend_name == "local":
         current_backend = Local(conf)
     elif backend_name == "spark":
         from backend.Spark import Spark
         current_backend = Spark(conf)
     else:
-        raise Exception(" Incorrect backend environment \"{}\"".format(backend))
+        msg = " Incorrect backend environment \"{}\"".format(backend_name)
+        raise Exception(msg)
+
 
 def include(includes_list):
     """
-    Includes a list of C++ headers to be
-    declared before execution.
+    Includes a list of C++ headers to be declared before execution.
 
     parameters
     ----------

--- a/PyRDF/backend/Backend.py
+++ b/PyRDF/backend/Backend.py
@@ -44,7 +44,7 @@ class Backend(ABC):
         'Graph'
     ]
 
-    initialization = staticmethod(lambda : None)
+    initialization = staticmethod(lambda: None)
 
     def __init__(self, config={}):
         """

--- a/PyRDF/backend/Backend.py
+++ b/PyRDF/backend/Backend.py
@@ -3,10 +3,11 @@ import functools
 
 ABC = ABCMeta('ABC', (object,), {})
 
+
 class Backend(ABC):
     """
-    Base class for RDataFrame backends. Subclasses
-    of this class need to implement the 'execute' method.
+    Base class for RDataFrame backends. Subclasses of this class need to
+    implement the 'execute' method.
 
     Attributes
     ----------
@@ -17,6 +18,7 @@ class Backend(ABC):
         Store user's initialization method, if defined.
 
     """
+
     supported_operations = [
         'Define',
         'Filter',
@@ -40,14 +42,13 @@ class Backend(ABC):
         'Reduce',
         'Aggregate',
         'Graph'
-        ]
+    ]
 
     initialization = staticmethod(lambda : None)
 
     def __init__(self, config={}):
         """
-        Creates a new instance of the
-        desired implementation of `Backend`.
+        Creates a new instance of the desired implementation of `Backend`.
 
         Parameters
         ----------
@@ -99,8 +100,15 @@ class Backend(ABC):
 
         """
         if operation_name not in self.supported_operations:
-            raise Exception("The current backend doesn't support \"{}\" !".format(operation_name))
+            raise Exception(
+                "The current backend doesn't support \"{}\" !"
+                .format(operation_name)
+            )
 
     @abstractmethod
     def execute(self, generator):
+        """
+        Subclasses must define how to run the RDataFrame graph on a given
+        environment.
+        """
         pass

--- a/PyRDF/backend/Dist.py
+++ b/PyRDF/backend/Dist.py
@@ -330,7 +330,8 @@ class Dist(Backend):
 
             Utils.declare_headers(includes)  # Declare headers if any
 
-            # Run initialization method to prepare the worker runtime environment
+            # Run initialization method to prepare the worker runtime
+            # environment
             initialization()
 
             # Build rdf

--- a/PyRDF/backend/Local.py
+++ b/PyRDF/backend/Local.py
@@ -2,10 +2,11 @@ import ROOT
 from .Backend import Backend
 from .Utils import Utils
 
+
 class Local(Backend):
     """
-    Backend that relies on the C++ implementation
-    of RDataFrame to locally execute the current graph.
+    Backend that relies on the C++ implementation of RDataFrame to locally
+    execute the current graph.
 
     Attributes
     ----------
@@ -14,6 +15,7 @@ class Local(Backend):
         backend.
 
     """
+
     def __init__(self, config={}):
         """
         Creates a new instance of the
@@ -29,18 +31,19 @@ class Local(Backend):
         """
         super(Local, self).__init__(config)
         operations_not_supported = [
-        'Take',
-        'Snapshot',
-        'Foreach',
-        'Reduce',
-        'Aggregate'
+            'Take',
+            'Snapshot',
+            'Foreach',
+            'Reduce',
+            'Aggregate',
         ]
         if ROOT.ROOT.IsImplicitMTEnabled():
             # Add `Range` operation only if multi-threading
             # is disabled.
             operations_not_supported.append('Range')
 
-        self.supported_operations = [op for op in self.supported_operations if op not in operations_not_supported]
+        self.supported_operations = [op for op in self.supported_operations
+                                     if op not in operations_not_supported]
         self.pyroot_rdf = None
 
     def execute(self, generator):
@@ -56,9 +59,9 @@ class Local(Backend):
         """
         from .. import includes
 
-        mapper = generator.get_callable() # Get the callable
+        mapper = generator.get_callable()  # Get the callable
 
-        Utils.declare_headers(includes) # Declare headers if any
+        Utils.declare_headers(includes)  # Declare headers if any
 
         # Run initialization method to prepare the worker runtime environment
         Backend.initialization()
@@ -66,12 +69,12 @@ class Local(Backend):
         if not self.pyroot_rdf:
             self.pyroot_rdf = ROOT.ROOT.RDataFrame(*generator.head_node.args)
 
-        values = mapper(self.pyroot_rdf) # Execute the mapper function
+        values = mapper(self.pyroot_rdf)  # Execute the mapper function
 
         # Get the action nodes in the same order as values
         nodes = generator.get_action_nodes()
 
-        values[0].GetValue() # Trigger event-loop
+        values[0].GetValue()  # Trigger event-loop
 
         for i in range(len(values)):
             # Set the obtained values and

--- a/PyRDF/backend/Spark.py
+++ b/PyRDF/backend/Spark.py
@@ -82,7 +82,7 @@ class Spark(Dist):
 
         Utils.declare_headers(includes)  # Declare headers if any
 
-        ranges = self.BuildRanges(self.npartitions)  # Get range pairs
+        ranges = self.build_ranges(self.npartitions)  # Get range pairs
 
         # Build parallel collection
         sc = self.sparkContext

--- a/PyRDF/backend/Spark.py
+++ b/PyRDF/backend/Spark.py
@@ -3,39 +3,40 @@ from .Dist import Dist
 from pyspark import SparkConf, SparkContext
 from .Utils import Utils
 
+
 class Spark(Dist):
     """
-    Backend that executes the computational graph
-    using using `Spark` framework for distributed
-    execution.
+    Backend that executes the computational graph using using `Spark` framework
+    for distributed execution.
 
     """
-    def __init__(self, config = {}):
+
+    MIN_NPARTITIONS = 2
+
+    def __init__(self, config={}):
         """
-        Creates an instance of the Spark
-        backend class.
+        Creates an instance of the Spark backend class.
 
         Parameters
         ----------
         config : dict (optional)
-            The config options for Spark backend. The default
-            value is an empty Python dictionary `{}`. Config
-            should be a dictionary of Spark configuration
-            options and their values with 'npartitions' as
-            the only allowed extra parameter.
+            The config options for Spark backend. The default value is an empty
+            Python dictionary `{}`. `config` should be a dictionary of Spark
+            configuration options and their values with 'npartitions' as the
+            only allowed extra parameter.
+
             For example :-
 
             config = {
-            'npartitions':20,
-            'spark.master':'myMasterURL',
-            'spark.executor.instances':10,
-            'spark.app.name':'mySparkAppName'
+                'npartitions':20,
+                'spark.master':'myMasterURL',
+                'spark.executor.instances':10,
+                'spark.app.name':'mySparkAppName'
             }
 
-            IMPORTANT NOTE :- If a SparkContext is already set
-            in the current environment, the Spark configuration
-            parameters from 'config' will be ignored and the already
-            existing SparkContext would be used.
+            IMPORTANT NOTE :- If a SparkContext is already set in the current
+            environment, the Spark configuration parameters from 'config' will
+            be ignored and the already existing SparkContext would be used.
 
         """
         super(Spark, self).__init__(config)
@@ -47,10 +48,14 @@ class Spark(Dist):
         self.sparkContext = SparkContext.getOrCreate(sparkConf)
 
         # Set the value of 'npartitions' if it doesn't exist
-        self.npartitions = self.npartitions or self.sparkContext.getConf().get('spark.executor.instances') or 2
+        self.npartitions = self._get_partitions()
 
+    def _get_partitions(self):
+        npart = (self.npartitions or
+                 self.sparkContext.getConf().get('spark.executor.instances') or
+                 Spark.MIN_NPARTITIONS)
         # getConf().get('spark.executor.instances') could return a string
-        self.npartitions = int(self.npartitions)
+        return int(npart)
 
     def ProcessAndMerge(self, mapper, reducer):
         """
@@ -75,10 +80,13 @@ class Spark(Dist):
         """
         from .. import includes
 
-        Utils.declare_headers(includes) # Declare headers if any
+        Utils.declare_headers(includes)  # Declare headers if any
 
-        ranges = self.BuildRanges(self.npartitions) # Get range pairs
+        ranges = self.BuildRanges(self.npartitions)  # Get range pairs
+
         # Build parallel collection
-        parallel_collection = self.sparkContext.parallelize(ranges, self.npartitions)
+        sc = self.sparkContext
+        parallel_collection = sc.parallelize(ranges, self.npartitions)
 
-        return parallel_collection.map(mapper).treeReduce(reducer) # Map-Reduce using Spark
+        # Map-Reduce using Spark
+        return parallel_collection.map(mapper).treeReduce(reducer)

--- a/PyRDF/backend/Utils.py
+++ b/PyRDF/backend/Utils.py
@@ -1,24 +1,22 @@
 import ROOT
 
-class Utils(object):
-    """
-    Class that houses general utility
-    functions.
 
-    """
+class Utils(object):
+    """Class that houses general utility functions."""
+
     @classmethod
     def declare_headers(cls, includes):
         """
-        Declares all required headers using
-        PyROOT's "ROOT.gInterpreter.Declare".
+        Declares all required headers using the ROOT's C++ Interpreter.
 
         parameters
         ----------
         includes : list
-            This list should consist of all necessary C++
-            headers as strings.
+            This list should consist of all necessary C++ headers as strings.
 
         """
         for header in includes:
-            if not ROOT.gInterpreter.Declare("#include \"{}\"\n".format(header)):
-                raise Exception("There was an error in including \"{}\" !".format(header))
+            include_code = "#include \"{}\"\n".format(header)
+            if not ROOT.gInterpreter.Declare(include_code):
+                msg = "There was an error in including \"{}\" !".format(header)
+                raise Exception(msg)

--- a/flake8.cfg
+++ b/flake8.cfg
@@ -7,26 +7,15 @@ exclude : tutorials
 # Ignore certain errors.
 #
 # The errors we suppress are:
-#   Docstring errors
-#   ~~~~~~~~~~~~~~~~
-#   By including the flake8-docstrings module, we also will fail on PEP257
-#   errors (D...).  For the moment, suppress all of the D... errors that would
-#   cause us to fail.  We may want to revisit this to make our code more PEP257
-#   conformant.
-#    D100 - Public module   (100) docstring missing.
-#    No  D101 - Public class    (101) docstring missing.
-#    No  D102 - Public method   (102) docstring missing.
-#    No  D103 - Public function (103) docstring missing.
-#     D104 - Missing docstring in public package.
-#    NO  D105 - Missing docstring in magic method.
-#    NO  D200 - One-line docstrings should fit on one line with quotes.
-#    NO  D201 - No blank lines allowed before (201) docstring.
-#    NO  D202 - No blank lines allowed after  (202) docstring.
-#    NO  D203 - 1 blank required before (203) class docstring.
-#    NO  D204 - 1 blank required after  (204) class docstring.
-#    D205 - Blank line required between one-line summary and description.
-#    D400 - First line should end with a period.
-#    D401 - First line should be in imperative mood.
-#    NO  D402 - First line should not be the function's "signature".
+# 
+# D1: Docstrings
+# - D100 - Public module docstring missing.
+# - D104 - Missing docstring in public package.
+# - D205 - Blank line required between one-line summary and description.
+# - D400 - First line should end with a period.
+# - D401 - First line should be in imperative mood.
 #
-ignore: D100,D104,D205,D400,D401
+# W5: Line breaking warning
+# - W503: line break before binary operator
+# - W504: line break after binary operator
+ignore: D100,D104,D205,D400,D401,W503,W504

--- a/flake8.cfg
+++ b/flake8.cfg
@@ -1,0 +1,32 @@
+[flake8]
+max-line-length: 80
+
+# Ignore tutorials
+exclude : tutorials
+
+# Ignore certain errors.
+#
+# The errors we suppress are:
+#   Docstring errors
+#   ~~~~~~~~~~~~~~~~
+#   By including the flake8-docstrings module, we also will fail on PEP257
+#   errors (D...).  For the moment, suppress all of the D... errors that would
+#   cause us to fail.  We may want to revisit this to make our code more PEP257
+#   conformant.
+#    D100 - Public module   (100) docstring missing.
+#    No  D101 - Public class    (101) docstring missing.
+#    No  D102 - Public method   (102) docstring missing.
+#    No  D103 - Public function (103) docstring missing.
+#     D104 - Missing docstring in public package.
+#    NO  D105 - Missing docstring in magic method.
+#    NO  D200 - One-line docstrings should fit on one line with quotes.
+#    NO  D201 - No blank lines allowed before (201) docstring.
+#    NO  D202 - No blank lines allowed after  (202) docstring.
+#    NO  D203 - 1 blank required before (203) class docstring.
+#    NO  D204 - 1 blank required after  (204) class docstring.
+#    D205 - Blank line required between one-line summary and description.
+#    D400 - First line should end with a period.
+#    D401 - First line should be in imperative mood.
+#    NO  D402 - First line should not be the function's "signature".
+#
+ignore: D100,D104,D205,D400,D401

--- a/setup.py
+++ b/setup.py
@@ -4,25 +4,25 @@ from setuptools import setup, find_packages
 #   from distutils.core import setup
 import sys
 
-req_file = open('requirements.txt','r')
+req_file = open('requirements.txt', 'r')
 req_list = [l.strip() for l in req_file]
 
 extra = {}
 if sys.version_info >= (3,):
-  extra['use_2to3'] = True
+    extra['use_2to3'] = True
 
 setup(
-  name = 'PyRDF',
-  packages = find_packages(),
-  version = '0.0.1',
-  description = 'Python Library for doing RDataFrame Analysis',
-  author = 'Shravan Murali',
-  author_email = 'shravanmurali@gmail.com',
-  maintainer='Javier Cervantes, Enric Tejedor',
-  maintainer_email='javier.cervantes@cern.ch, etejedor@cern.ch',
-  install_requires= req_list,
-  url = 'https://github.com/JavierCVilla/PyRDF',
-  keywords = [],
-  classifiers = [],
-  license='MIT License'
+    name='PyRDF',
+    packages=find_packages(),
+    version='0.0.1',
+    description='Python Library for doing RDataFrame Analysis',
+    author='Shravan Murali',
+    author_email='shravanmurali@gmail.com',
+    maintainer='Javier Cervantes, Enric Tejedor',
+    maintainer_email='javier.cervantes@cern.ch, etejedor@cern.ch',
+    install_requires=req_list,
+    url='https://github.com/JavierCVilla/PyRDF',
+    keywords=[],
+    classifiers=[],
+    license='MIT License'
 )

--- a/tests/integration/local/test_dataframe_histograms.py
+++ b/tests/integration/local/test_dataframe_histograms.py
@@ -1,21 +1,31 @@
 import unittest
-import ROOT, PyRDF
+import ROOT
+import PyRDF
+
 
 class HistogramsFromRDF(unittest.TestCase):
+    """
+    Same histogram operations in PyRDF with Local backend and RDF has to produce
+    the same results
+
+    """
+
     @classmethod
     def setUp(cls):
+        """Fix the seed"""
         ROOT.gRandom.SetSeed(1)
 
     def test_histo1D(self):
+        """Run the same code with PyRDF and RDF using the cpp interpreter"""
         ROOT.gRandom.SetSeed(1)
-        tdf = PyRDF.RDataFrame(64)
-        g = tdf.Define("r","gRandom->Gaus(0,1)")
-        h1Proxy = g.Histo1D(("h1","h1",64, -2., 2.),"r")
+        rdf = PyRDF.RDataFrame(64)
+        g = rdf.Define("r", "gRandom->Gaus(0,1)")
+        h1Proxy = g.Histo1D(("h1", "h1", 64, -2., 2.), "r")
         h1 = h1Proxy.GetValue()
 
         cppCode = 'gRandom->SetSeed(1);' + \
-                  'ROOT::RDataFrame tdf(64);' + \
-                  'auto g = tdf.Define("r","gRandom->Gaus(0,1)");' + \
+                  'ROOT::RDataFrame rdf(64);' + \
+                  'auto g = rdf.Define("r","gRandom->Gaus(0,1)");' + \
                   'auto h2Proxy = g.Histo1D({"h1","h1",64, -2., 2.},"r");'
         ROOT.gInterpreter.ProcessLine(cppCode)
         h2 = ROOT.h2Proxy.GetValue()

--- a/tests/integration/local/test_dataframe_histograms.py
+++ b/tests/integration/local/test_dataframe_histograms.py
@@ -34,5 +34,6 @@ class HistogramsFromRDF(unittest.TestCase):
         self.assertEqual(h1.GetMean(), h2.GetMean())
         self.assertEqual(h1.GetStdDev(), h2.GetStdDev())
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/local/test_dataframe_misc.py
+++ b/tests/integration/local/test_dataframe_misc.py
@@ -1,19 +1,26 @@
 import unittest
-import ROOT, PyRDF
+import ROOT
+import PyRDF
+
 
 class MiscTests(unittest.TestCase):
+    """Misc tests"""
+
     @classmethod
     def setUpClass(cls):
-        # load all libs and autoparse
-        df=ROOT.ROOT.RDataFrame(1)
+        """Load all libs and autoparse"""
+        ROOT.ROOT.RDataFrame(1)
 
     def test_lazy_define(self):
-        df=PyRDF.RDataFrame(10)
+        """Check laziness"""
+        df = PyRDF.RDataFrame(10)
         ROOT.gInterpreter.ProcessLine('int myCount = 0;')
+        cppcode = 'cout << "This should not be triggered!!" << endl; ' \
+                  'myCount++; return 1;'
         h = df.Define('a', 'static int i = 0; return i++;')\
               .Filter('a > 100')\
-              .Define('xx', ' cout << "This should not be triggered!!" << endl; myCount++; return 1;')\
-              .Histo1D('xx') # this is to check if the define is triggered!
+              .Define('xx', cppcode)\
+              .Histo1D('xx')  # this is to check if the define is triggered!
         h.GetMean()
         self.assertEqual(0, ROOT.myCount)
 

--- a/tests/integration/local/test_dataframe_misc.py
+++ b/tests/integration/local/test_dataframe_misc.py
@@ -24,5 +24,6 @@ class MiscTests(unittest.TestCase):
         h.GetMean()
         self.assertEqual(0, ROOT.myCount)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/local/test_headers_include.py
+++ b/tests/integration/local/test_headers_include.py
@@ -1,15 +1,13 @@
-import unittest, PyRDF, ROOT
+import unittest
+import PyRDF
+
 
 class IncludesLocalTest(unittest.TestCase):
-    """
-    An integration test to check that the required
-    header files are properly included.
+    """Check that the required header files are properly included."""
 
-    """
     def test_includes_function_with_filter_op(self):
         """
-        An integration test to check that the filter
-        operation is able to use C++ functions that
+        Check that the filter operation is able to use C++ functions that
         were include using header files.
 
         """

--- a/tests/integration/spark/test_include_headers.py
+++ b/tests/integration/spark/test_include_headers.py
@@ -1,15 +1,18 @@
-import unittest, PyRDF, ROOT, math
+import unittest
+import PyRDF
+import math
+
 
 class IncludesSparkTest(unittest.TestCase):
     """
-    An integration test to check that the required
-    header files are properly included in Spark environment.
+    Check that the required header files are properly included in Spark
+    environment.
 
     """
+
     def test_includes_function_with_filter_and_histo(self):
         """
-        An integration test to check that the filter
-        operation is able to use C++ functions that
+        Check that the filter operation is able to use C++ functions that
         were included using header files.
 
         """
@@ -23,10 +26,12 @@ class IncludesSparkTest(unittest.TestCase):
         histo = rdf_filtered.Histo1D("tdfentry_")
 
         # The expected results after filtering
-        required_numbers = range(5) # The actual set of numbers required after filtering
+        # The actual set of numbers required after filtering
+        required_numbers = range(5)
         required_size = len(required_numbers)
-        required_mean = sum(required_numbers)/float(required_size)
-        required_stdDev = math.sqrt(sum((x - required_mean)**2 for x in required_numbers)/required_size)
+        required_mean = sum(required_numbers) / float(required_size)
+        required_stdDev = math.sqrt(sum((x - required_mean)**2
+                                    for x in required_numbers) / required_size)
 
         # Compare the sizes of equivalent set of numbers
         self.assertEqual(histo.GetEntries(), float(required_size))

--- a/tests/integration/spark/test_inv_mass.py
+++ b/tests/integration/spark/test_inv_mass.py
@@ -1,28 +1,23 @@
-import unittest, PyRDF
+import unittest
+import PyRDF
+from collections import namedtuple
+
 
 class SparkHistogramsTest(unittest.TestCase):
-    """
-    Integration tests to check the working of PyRDF.
+    """Integration tests to check the working of PyRDF."""
 
-    """
     @classmethod
     def tearDown(cls):
-        """
-        Cleans up the `SparkContext` objects
-        that were created.
-
-        """
+        """Clean up the `SparkContext` objects that were created."""
         from pyspark import SparkContext
         context = SparkContext.getOrCreate()
         context.stop()
 
     def build_pyrdf_graph(self):
-        """
-        Creates a PyRDF graph with a fixed
-        set of operations and returns it.
-
-        """
-        rdf = PyRDF.RDataFrame("data", ['https://root.cern/files/teaching/CMS_Open_Dataset.root',])
+        """Create a PyRDF graph with a fixed set of operations and return it."""
+        treename = "data"
+        files = ['https://root.cern/files/teaching/CMS_Open_Dataset.root', ]
+        rdf = PyRDF.RDataFrame(treename, files)
 
         # Define the analysis cuts
         chargeCutStr = "C1 != C2"
@@ -31,42 +26,49 @@ class SparkHistogramsTest(unittest.TestCase):
         rdf_f = rdf.Filter(chargeCutStr, "Opposite Charge") \
                    .Filter(etaCutStr, "Central Muons") \
                    .Filter(ptCutStr, "Sane Pt")
-                
+
         # Create the invariant mass column
-        invMassFormulaStr = "sqrt(pow(E1+E2, 2) - (pow(px1+px2, 2) + pow(py1+py2, 2) + pow(pz1+pz2, 2)))"
+        invMassFormulaStr = ("sqrt(pow(E1+E2, 2) - (pow(px1+px2, 2) +"
+                             "pow(py1+py2, 2) + pow(pz1+pz2, 2)))")
         rdf_fd = rdf_f.Define("invMass", invMassFormulaStr)
-        
+
         # Create the histograms
-        pt1_h = rdf.Histo1D(("","",128,1,1200), "pt1")
-        pt2_h = rdf.Histo1D(("","",128,1,1200), "pt2")
-        invMass_h = rdf_fd.Histo1D(("invMass","CMS Opendata;#mu#mu mass [GeV];Events",512,5,110), "invMass")
+        pt1_h = rdf.Histo1D(("", "", 128, 1, 1200), "pt1")
+        pt2_h = rdf.Histo1D(("", "", 128, 1, 1200), "pt2")
+        model = ("invMass", "CMS Opendata;#mu#mu mass[GeV];Events", 512, 5, 110)
+        invMass_h = rdf_fd.Histo1D(model, "invMass")
         import ROOT
         pi = ROOT.TMath.Pi()
-        phis_h = rdf_fd.Histo2D(("", "", 64, -pi, pi, 64, -pi, pi), "phi1", "phi2")
+        model = ("", "", 64, -pi, pi, 64, -pi, pi)
+        phis_h = rdf_fd.Histo2D(model, "phi1", "phi2")
 
         return pt1_h, pt2_h, invMass_h, phis_h
 
     def test_spark_histograms(self):
-        """
-        Integration test to check that Spark
-        backend works the same way as local.
-
-        """
+        """Check that Spark backend works the same way as local."""
+        physics_variables = ['pt1_h', 'pt2_h', 'invMass_h', 'phis_h']
         # Spark execution
-        PyRDF.use("spark", {'npartitions':5})
-        pt1_h_spark, pt2_h_spark, invMass_h_spark, phis_h_spark = self.build_pyrdf_graph()
-        pt1_h_spark.Draw("PL PLC PMC") # Trigger Event-loop, Spark
+        PyRDF.use("spark", {'npartitions': 5})
+
+        SparkResult = namedtuple('SparkResult', physics_variables)
+        spark = SparkResult(*self.build_pyrdf_graph())
+
+        spark.pt1_h.Draw("PL PLC PMC")  # Trigger Event-loop, Spark
 
         # Local execution
         PyRDF.use("local")
-        pt1_h_local, pt2_h_local, invMass_h_local, phis_h_local = self.build_pyrdf_graph()
-        pt1_h_local.Draw("PL PLC PMC") # Trigger Event-loop, Local
+
+        LocalResult = namedtuple('LocalResult', physics_variables)
+        local = LocalResult(*self.build_pyrdf_graph())
+
+        local.pt1_h.Draw("PL PLC PMC")  # Trigger Event-loop, Local
 
         # Assert 'pt1_h' histogram
-        self.assertEqual(pt1_h_spark.GetEntries(), pt1_h_local.GetEntries())
+        self.assertEqual(spark.pt1_h.GetEntries(), local.pt1_h.GetEntries())
         # Assert 'pt2_h' histogram
-        self.assertEqual(pt2_h_spark.GetEntries(), pt2_h_local.GetEntries())
+        self.assertEqual(spark.pt2_h.GetEntries(), local.pt2_h.GetEntries())
         # Assert 'invMass_h' histogram
-        self.assertEqual(invMass_h_spark.GetEntries(), invMass_h_local.GetEntries())
+        self.assertEqual(spark.invMass_h.GetEntries(),
+                         local.invMass_h.GetEntries())
         # Assert 'phis_h' histogram
-        self.assertEqual(phis_h_spark.GetEntries(), phis_h_local.GetEntries())
+        self.assertEqual(spark.phis_h.GetEntries(), local.phis_h.GetEntries())

--- a/tests/integration/spark/test_reducer_merge.py
+++ b/tests/integration/spark/test_reducer_merge.py
@@ -1,35 +1,27 @@
-import unittest, PyRDF, ROOT
+import unittest
+import ROOT
+import PyRDF
+
 
 class ReducerMergeTest(unittest.TestCase):
-    """
-    Integration tests to check the working of merge operations
-    in the reducer function.
+    """Check the working of merge operations in the reducer function."""
 
-    """
     @classmethod
     def setUpClass(cls):
-        """
-        Set up method to select Spark backend
-        before running all the tests.
-
-        """
-        PyRDF.use("spark", {'npartitions':2, 'spark.executor.instances':2})
+        """Select Spark backend before running all the tests."""
+        PyRDF.use("spark", {'npartitions': 2, 'spark.executor.instances': 2})
 
     @classmethod
     def tearDownClass(cls):
         """
-        Restore current_backend to default Local backend after running all tests
+        Restore global current_backend to default Local backend after running
+        all tests
 
         """
         PyRDF.use("local")
 
-
     def assertHistoOrProfile(self, obj_1, obj_2):
-        """
-        Asserts equality between two 'ROOT.TH1' or
-        'ROOT.TH2' objects.
-
-        """
+        """Asserts equality between two 'ROOT.TH1' or 'ROOT.TH2' objects."""
         # Compare the sizes of equivalent objects
         self.assertEqual(obj_1.GetEntries(), obj_2.GetEntries())
 
@@ -41,83 +33,71 @@ class ReducerMergeTest(unittest.TestCase):
 
     def define_two_columns(self, rdf):
         """
-        Helper method that Defines and returns
-        two columns with definitions "x = tdfentry_"
-        and "y = tdfentry_ * tdfentry_".
+        Helper method that Defines and returns two columns with definitions
+        "x = rdfentry_" and "y = rdfentry_ * rdfentry_".
 
         """
-        return rdf.Define("x", "tdfentry_").Define("y", "tdfentry_*tdfentry_")
+        return rdf.Define("x", "rdfentry_").Define("y", "rdfentry_*rdfentry_")
 
     def define_three_columns(self, rdf):
         """
-        Helper method that Defines and returns three columns
-        with definitions "x = tdfentry_", "y = tdfentry_ * tdfentry_"
-        and "z = tdfentry_ * tdfentry_ * tdfentry_".
+        Helper method that Defines and returns three columns with definitions
+        "x = rdfentry_", "y = rdfentry_ * rdfentry_" and
+        "z = rdfentry_ * rdfentry_ * rdfentry_".
 
         """
-        return rdf.Define("x", "tdfentry_").Define("y", "tdfentry_*tdfentry_").Define("z", "tdfentry_*tdfentry_*tdfentry_")
+        return rdf.Define("x", "rdfentry_")\
+                  .Define("y", "rdfentry_*rdfentry_")\
+                  .Define("z", "rdfentry_*rdfentry_*rdfentry_")
 
     def test_histo1d_merge(self):
-        """
-        Integration test to check the working of
-        Histo1D merge operation in the reducer.
-
-        """
+        """Check the working of Histo1D merge operation in the reducer."""
         # Operations with PyRDF
         rdf_py = PyRDF.RDataFrame(10)
-        histo_py = rdf_py.Histo1D("tdfentry_")
+        histo_py = rdf_py.Histo1D("rdfentry_")
 
         # Operations with PyROOT
         rdf_cpp = ROOT.ROOT.RDataFrame(10)
-        histo_cpp = rdf_cpp.Histo1D("tdfentry_")
+        histo_cpp = rdf_cpp.Histo1D("rdfentry_")
 
         # Compare the 2 histograms
         self.assertHistoOrProfile(histo_py, histo_cpp)
 
     def test_histo2d_merge(self):
-        """
-        Integration test to check the working of
-        Histo2D merge operation in the reducer.
+        """Check the working of Histo2D merge operation in the reducer."""
+        modelTH2D = ("", "", 64, -4, 4, 64, -4, 4)
 
-        """
         # Operations with PyRDF
         rdf_py = PyRDF.RDataFrame(10)
         columns_py = self.define_two_columns(rdf_py)
-        histo_py = columns_py.Histo2D(("", "", 64, -4, 4, 64, -4, 4), "x", "y")
+        histo_py = columns_py.Histo2D(modelTH2D, "x", "y")
 
         # Operations with PyROOT
         rdf_cpp = ROOT.ROOT.RDataFrame(10)
         columns_cpp = self.define_two_columns(rdf_cpp)
-        histo_cpp = columns_cpp.Histo2D(("", "", 64, -4, 4, 64, -4, 4), "x", "y")
+        histo_cpp = columns_cpp.Histo2D(modelTH2D, "x", "y")
 
         # Compare the 2 histograms
         self.assertHistoOrProfile(histo_py, histo_cpp)
 
     def test_histo3d_merge(self):
-        """
-        Integration test to check the working of
-        Histo3D merge operation in the reducer.
-
-        """
+        """Check the working of Histo3D merge operation in the reducer."""
+        modelTH3D = ("", "", 64, -4, 4, 64, -4, 4, 64, -4, 4)
         # Operations with PyRDF
         rdf_py = PyRDF.RDataFrame(10)
         columns_py = self.define_three_columns(rdf_py)
-        histo_py = columns_py.Histo3D(("", "", 64, -4, 4, 64, -4, 4, 64, -4, 4), "x", "y", "z")
+        histo_py = columns_py.Histo3D(modelTH3D, "x", "y", "z")
 
         # Operations with PyROOT
         rdf_cpp = ROOT.ROOT.RDataFrame(10)
         columns_cpp = self.define_three_columns(rdf_cpp)
-        histo_cpp = columns_cpp.Histo3D(("", "", 64, -4, 4, 64, -4, 4, 64, -4, 4), "x", "y", "z")
+        histo_cpp = columns_cpp.Histo3D(modelTH3D, "x", "y", "z")
 
         # Compare the 2 histograms
         self.assertHistoOrProfile(histo_py, histo_cpp)
 
     def test_profile1d_merge(self):
-        """
-        Integration test to check the working of
-        Profile1D merge operation in the reducer.
-
-        """
+        """Check the working of Profile1D merge operation in the reducer."""
         # Operations with PyRDF
         rdf_py = PyRDF.RDataFrame(10)
         columns_py = self.define_two_columns(rdf_py)
@@ -132,31 +112,26 @@ class ReducerMergeTest(unittest.TestCase):
         self.assertHistoOrProfile(profile_py, profile_cpp)
 
     def test_profile2d_merge(self):
-        """
-        Integration test to check the working of
-        Profile2D merge operation in the reducer.
+        """Check the working of Profile2D merge operation in the reducer."""
+        model = ("", "", 64, -4, 4, 64, -4, 4)
 
-        """
         # Operations with PyRDF
         rdf_py = PyRDF.RDataFrame(10)
         columns_py = self.define_three_columns(rdf_py)
-        profile_py = columns_py.Profile2D(("", "", 64, -4, 4, 64, -4, 4), "x", "y", "z")
+        profile_py = columns_py.Profile2D(model, "x", "y", "z")
 
         # Operations with PyROOT
         rdf_cpp = ROOT.ROOT.RDataFrame(10)
         columns_cpp = self.define_three_columns(rdf_cpp)
-        profile_cpp = columns_cpp.Profile2D(("", "", 64, -4, 4, 64, -4, 4), "x", "y", "z")
+        profile_cpp = columns_cpp.Profile2D(model, "x", "y", "z")
 
         # Compare the 2 profiles
         self.assertHistoOrProfile(profile_py, profile_cpp)
 
-    @unittest.skipIf(ROOT.gROOT.GetVersion() < '6.16', "Graph featured included in ROOT-6.16 for the first time")
+    @unittest.skipIf(ROOT.gROOT.GetVersion() < '6.16',
+                     "Graph featured included in ROOT-6.16 for the first time")
     def test_tgraph_merge(self):
-        """
-        Integration test to check the working of
-        TGraph merge operation in the reducer.
-
-        """
+        """Check the working of TGraph merge operation in the reducer."""
         # Operations with PyRDF
         rdf_py = PyRDF.RDataFrame(10)
         columns_py = self.define_two_columns(rdf_py)

--- a/tests/unit/backend/test_common.py
+++ b/tests/unit/backend/test_common.py
@@ -98,15 +98,14 @@ class DeclareHeadersTest(unittest.TestCase):
         self.assertEqual(ROOT.f1(2), 2)
         self.assertEqual(ROOT.f2("myString"), "myString")
 
-class InitializationTest(unittest.TestCase):
-    """
-    Check the initialize method
 
-    """
+class InitializationTest(unittest.TestCase):
+    """Check the initialize method"""
 
     def test_initialization(self):
         """
-        Check that the user initialization method is assigned to the backend
+        Check that the user initialization method is assigned to the current
+        backend.
 
         """
         def returnNumber(n):

--- a/tests/unit/backend/test_common.py
+++ b/tests/unit/backend/test_common.py
@@ -1,34 +1,25 @@
-import PyRDF, unittest, ROOT
+import unittest
+import ROOT
+import PyRDF
 from PyRDF.backend.Utils import Utils
 
-class SelectionTest(unittest.TestCase):
-    """
-    A series of tests to check the
-    accuracy of 'PyRDF.use' method.
 
-    """
+class SelectionTest(unittest.TestCase):
+    """Check 'PyRDF.use' method."""
 
     def test_future_env_select(self):
-        """
-        Test to check if a future environment
-        throws a NotImplementedError.
-
-        """
-
+        """Non implemented backends throw a NotImplementedError."""
         with self.assertRaises(NotImplementedError):
             PyRDF.use("dask")
 
-class BackendInitTest(unittest.TestCase):
-    """
-    Tests to ensure that the Backend abstract
-    class cannot be instantiated.
 
-    """
+class BackendInitTest(unittest.TestCase):
+    """Backend abstract class cannot be instantiated."""
+
     def test_backend_init_error(self):
         """
-        Test case to check that any attempt to
-        instantiate the `Backend` abstract class
-        results in a `TypeError`.
+        Any attempt to instantiate the `Backend` abstract class results in
+        a `TypeError`.
 
         """
         with self.assertRaises(TypeError):
@@ -36,9 +27,8 @@ class BackendInitTest(unittest.TestCase):
 
     def test_subclass_without_method_error(self):
         """
-        Test case to check that creation of a
-        subclass without implementing `execute`
-        method throws a `TypeError`.
+        Creation of a subclass without implementing `execute` method throws
+        a `TypeError`.
 
         """
         class TestBackend(PyRDF.backend.Backend.Backend):
@@ -47,44 +37,31 @@ class BackendInitTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             TestBackend()
 
+
 class IncludeHeadersTest(unittest.TestCase):
-    """
-    Tests to check the working of 'PyRDF.include' function.
+    """Tests to check the working of 'PyRDF.include' function."""
 
-    """
     def tearDown(self):
-        """
-        Resets the module-level variable
-        'includes' to an empty list.
-
-        """
-        PyRDF.includes = [] # reset includes
+        """Resets the module-level variable 'includes' to an empty list."""
+        PyRDF.includes = []  # reset includes
 
     def test_default_empty_list_include(self):
         """
-        Test case to ensure that 'PyRDF.include' function
-        raises a TypeError if no parameter is given.
+        'PyRDF.include' function raises a TypeError if no parameter is
+        given.
 
         """
         with self.assertRaises(TypeError):
             PyRDF.include()
 
     def test_string_include(self):
-        """
-        Test case to check the working of 'PyRDF.include'
-        function when a single string is passed to it.
-
-        """
+        """'PyRDF.include' with a single string."""
         PyRDF.include("header1")
 
         self.assertListEqual(PyRDF.includes, ["header1"])
 
     def test_list_include(self):
-        """
-        Test case to check the working of 'PyRDF.include'
-        function when a list of strings is passed to it.
-
-        """
+        """'PyRDF.include' with a list of strings."""
         PyRDF.include(["header1"])
 
         self.assertListEqual(PyRDF.includes, ["header1"])
@@ -99,33 +76,23 @@ class IncludeHeadersTest(unittest.TestCase):
         PyRDF.include(["header1", "header2"])
         PyRDF.include(["header3", "header4", "header5"])
 
-        self.assertListEqual(PyRDF.includes, ["header1", "header2", "header3", "header4", "header5"])
+        required_list = ["header1", "header2", "header3", "header4", "header5"]
+        self.assertListEqual(PyRDF.includes, required_list)
+
 
 class DeclareHeadersTest(unittest.TestCase):
-    """
-    Tests to check the working of the static
-    method 'declare_headers' in Backend class.
+    """Static method 'declare_headers' in Backend class."""
 
-    """
     def test_single_header_declare(self):
-        """
-        Test case to check the working of 'declare_headers'
-        function when a single header needs to be included.
-
-        """
+        """'declare_headers' with a single header to be included."""
         Utils.declare_headers(["tests/unit/backend/test_headers/header1.hxx"])
 
         self.assertEqual(ROOT.f(1), True)
 
     def test_multiple_headers_declare(self):
-        """
-        Test case to check the working of 'declare_headers'
-        function when multiple headers need to be included.
-
-        """
+        """'declare_headers' with multiple headers to be included."""
         Utils.declare_headers(["tests/unit/backend/test_headers/header1.hxx",
-                               "tests/unit/backend/test_headers/header2.hxx"
-                              ])
+                               "tests/unit/backend/test_headers/header2.hxx"])
 
         self.assertEqual(ROOT.f(1), True)
         self.assertEqual(ROOT.f1(2), 2)

--- a/tests/unit/backend/test_dist.py
+++ b/tests/unit/backend/test_dist.py
@@ -1,20 +1,20 @@
-import PyRDF, unittest, ROOT
+import unittest
+import PyRDF
 from PyRDF.backend.Dist import Dist
 
+
 def rangesToTuples(ranges):
+    """Convert range objects to tuples with the shape (start, end)"""
     return map(lambda r: (r.start, r.end), ranges)
 
-class DistBackendInitTest(unittest.TestCase):
-    """
-    Tests to ensure that the Dist abstract
-    class cannot be instantiated.
 
-    """
+class DistBackendInitTest(unittest.TestCase):
+    """Dist abstract class cannot be instantiated."""
+
     def test_dist_init_error(self):
         """
-        Test case to check that any attempt to
-        instantiate the `Dist` abstract class
-        results in a `TypeError`.
+        Any attempt to instantiate the `Dist` abstract class results in
+        a `TypeError`.
 
         """
         with self.assertRaises(TypeError):
@@ -22,8 +22,7 @@ class DistBackendInitTest(unittest.TestCase):
 
     def test_subclass_without_method_error(self):
         """
-        Test case to check that creation of a
-        subclass without implementing `processAndMerge`
+        Creation of a subclass without implementing `processAndMerge`
         method throws a `TypeError`.
 
         """
@@ -33,29 +32,21 @@ class DistBackendInitTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             TestBackend()
 
+
 class DistBuildRangesTest(unittest.TestCase):
-    """
-    Tests to check the working of the `BuildRanges`
-    instance method in `Dist` class.
+    """`BuildRanges instance method in `Dist` class."""
 
-    """
     class TestBackend(Dist):
-        """
-        A Dummy backend class to test the
-        BuildRanges method in Dist class.
+        """Dummy backend to test the BuildRanges method in Dist class."""
 
-        """
         def ProcessAndMerge(self, mapper, reducer):
-            """
-            Dummy implementation of ProcessAndMerge.
-
-            """
+            """Dummy implementation of ProcessAndMerge."""
             pass
 
     def test_nentries_multipleOf_npartitions(self):
         """
-        Test cases that check the working of `BuildRanges`
-        method when `nentries` is a multiple of `npartitions`.
+        `BuildRanges` method when the number of entries is a multiple of the
+        number of partitions.
 
         """
         backend = DistBuildRangesTest.TestBackend()
@@ -64,21 +55,26 @@ class DistBuildRangesTest(unittest.TestCase):
         nentries_large = 100
         npartitions_large = 10
 
-        ranges_small = rangesToTuples(backend._getBalancedRanges(nentries_small, npartitions_small))
-        ranges_large = rangesToTuples(backend._getBalancedRanges(nentries_large, npartitions_large))
+        # First case
+        rng = backend._get_balanced_ranges(nentries_small, npartitions_small)
+        ranges_small = rangesToTuples(rng)
+
+        # Second case
+        rng = backend._get_balanced_ranges(nentries_large, npartitions_large)
+        ranges_large = rangesToTuples(rng)
 
         ranges_small_reqd = [(0, 2), (2, 4), (4, 6), (6, 8), (8, 10)]
         ranges_large_reqd = [
-        (0, 10),
-        (10, 20),
-        (20, 30),
-        (30, 40),
-        (40, 50),
-        (50, 60),
-        (60, 70),
-        (70, 80),
-        (80, 90),
-        (90, 100)
+            (0, 10),
+            (10, 20),
+            (20, 30),
+            (30, 40),
+            (40, 50),
+            (50, 60),
+            (60, 70),
+            (70, 80),
+            (80, 90),
+            (90, 100)
         ]
 
         self.assertListEqual(ranges_small, ranges_small_reqd)
@@ -86,8 +82,8 @@ class DistBuildRangesTest(unittest.TestCase):
 
     def test_nentries_not_multipleOf_npartitions(self):
         """
-        Test cases that check the working of `BuildRanges` method
-        when `nentries` is not a multiple of `npartitions`.
+        `BuildRanges` method when then number of entries is not a multiple of
+        the number of partitions.
 
         """
         backend = DistBuildRangesTest.TestBackend()
@@ -98,10 +94,13 @@ class DistBuildRangesTest(unittest.TestCase):
 
         # Example in which fractional part of
         # (nentries/npartitions) >= 0.5
-        ranges_1 = rangesToTuples(backend._getBalancedRanges(nentries_1, npartitions_1))
+        rng = backend._get_balanced_ranges(nentries_1, npartitions_1)
+        ranges_1 = rangesToTuples(rng)
+
         # Example in which fractional part of
         # (nentries/npartitions) < 0.5
-        ranges_2 = rangesToTuples(backend._getBalancedRanges(nentries_2, npartitions_2))
+        rng = backend._get_balanced_ranges(nentries_2, npartitions_2)
+        ranges_2 = rangesToTuples(rng)
 
         # Required output pairs
         ranges_1_reqd = [(0, 3), (3, 6), (6, 8), (8, 10)]
@@ -112,15 +111,16 @@ class DistBuildRangesTest(unittest.TestCase):
 
     def test_nentries_greater_than_npartitions(self):
         """
-        Test case that check the working of `BuildRanges` method
-        when the value of `nentries` is lesser than `npartitions`.
+        `BuildRanges` method when the number of entries is smaller than the
+        number of partitions.
 
         """
         backend = DistBuildRangesTest.TestBackend()
         nentries = 5
-        npartitions = 7 # > nentries
+        npartitions = 7  # > nentries
 
-        ranges = rangesToTuples(backend._getBalancedRanges(nentries, npartitions))
+        rng = backend._get_balanced_ranges(nentries, npartitions)
+        ranges = rangesToTuples(rng)
 
         ranges_reqd = [(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]
 
@@ -128,7 +128,7 @@ class DistBuildRangesTest(unittest.TestCase):
 
     def test_clustered_ranges_with_one_cluster(self):
         """
-        Check that _getClusteredRanges returns one range when the dataset
+        Check that _get_clustered_ranges returns one range when the dataset
         contains a single cluster and the number of partitions is 1
 
         """
@@ -138,16 +138,17 @@ class DistBuildRangesTest(unittest.TestCase):
         nentries = 10
         npartitions = 1
 
-        crs = backend._getClusteredRanges(nentries, npartitions, treename, filelist)
+        crs = backend._get_clustered_ranges(nentries, npartitions, treename,
+                                            filelist)
         ranges = rangesToTuples(crs)
 
         ranges_reqd = [(0L, 10L)]
 
         self.assertListEqual(ranges, ranges_reqd)
 
-    def test_warning_in_clustered_ranges_npartitions_greater_than_clusters(self):
+    def test_warning_when_npartitions_greater_than_clusters(self):
         """
-        Check that _getClusteredRanges raises a warning when the number of
+        Check that _get_clustered_ranges raises a warning when the number of
         partitions is bigger than the number of clusters in the dataset.
 
         """
@@ -163,7 +164,8 @@ class DistBuildRangesTest(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as w:
             # Trigger warning
-            crs = backend._getClusteredRanges(nentries, npartitions, treename, filelist)
+            crs = backend._get_clustered_ranges(nentries, npartitions, treename,
+                                                filelist)
             ranges = rangesToTuples(crs)
 
             # Verify ranges
@@ -174,7 +176,7 @@ class DistBuildRangesTest(unittest.TestCase):
 
     def test_clustered_ranges_with_two_clusters_two_partitions(self):
         """
-        Check that _getClusteredRanges creates clustered ranges respecting
+        Check that _get_clustered_ranges creates clustered ranges respecting
         the cluster boundaries even if that implies to have ranges with very
         different numbers of entries.
 
@@ -185,11 +187,12 @@ class DistBuildRangesTest(unittest.TestCase):
         nentries = 1000
         npartitions = 2
 
-        crs = backend._getClusteredRanges(nentries, npartitions, treename, filelist)
+        crs = backend._get_clustered_ranges(nentries, npartitions, treename,
+                                            filelist)
         ranges = rangesToTuples(crs)
 
         ranges_reqd = [
-            (0L,   777L),
+            (0L, 777L),
             (777L, 1000L)
         ]
 
@@ -197,7 +200,7 @@ class DistBuildRangesTest(unittest.TestCase):
 
     def test_clustered_ranges_with_four_clusters_four_partitions(self):
         """
-        Check that _getClusteredRanges creates clustered ranges as equal as
+        Check that _get_clustered_ranges creates clustered ranges as equal as
         possible for four partitions
 
         """
@@ -207,11 +210,12 @@ class DistBuildRangesTest(unittest.TestCase):
         nentries = 1000
         npartitions = 4
 
-        crs = backend._getClusteredRanges(nentries, npartitions, treename, filelist)
+        crs = backend._get_clustered_ranges(nentries, npartitions, treename,
+                                            filelist)
         ranges = rangesToTuples(crs)
 
         ranges_reqd = [
-            (0L,   250L),
+            (0L, 250L),
             (250L, 500L),
             (500L, 750L),
             (750L, 1000L)
@@ -221,7 +225,7 @@ class DistBuildRangesTest(unittest.TestCase):
 
     def test_clustered_ranges_with_many_clusters_four_partitions(self):
         """
-        Check that _getClusteredRanges creates clustered ranges as equal as
+        Check that _get_clustered_ranges creates clustered ranges as equal as
         possible for four partitions
 
         """
@@ -231,11 +235,12 @@ class DistBuildRangesTest(unittest.TestCase):
         nentries = 1000
         npartitions = 4
 
-        crs = backend._getClusteredRanges(nentries, npartitions, treename, filelist)
+        crs = backend._get_clustered_ranges(nentries, npartitions, treename,
+                                            filelist)
         ranges = rangesToTuples(crs)
 
         ranges_reqd = [
-            (0L,   250L),
+            (0L, 250L),
             (250L, 500L),
             (500L, 750L),
             (750L, 1000L)
@@ -245,7 +250,7 @@ class DistBuildRangesTest(unittest.TestCase):
 
     def test_clustered_ranges_with_many_clusters_many_partitions(self):
         """
-        Check that _getClusteredRanges creates clustered ranges as equal as
+        Check that _get_clustered_ranges creates clustered ranges as equal as
         possible for the maximum number of possible partitions (number of
         clusters)
 
@@ -256,79 +261,82 @@ class DistBuildRangesTest(unittest.TestCase):
         nentries = 1000
         npartitions = 1000
 
-        crs = backend._getClusteredRanges(nentries, npartitions, treename, filelist)
+        crs = backend._get_clustered_ranges(nentries, npartitions, treename,
+                                            filelist)
         ranges = rangesToTuples(crs)
 
         start = 0
         end = 1000
         step = 1
 
-        ranges_reqd = [ (a,b) for a,b in zip(range(start, end, step), range(step, end+1, step)) ]
+        ranges_reqd = [(a, b) for a, b in zip(range(start, end, step),
+                                              range(step, end + 1, step))]
 
         self.assertListEqual(ranges, ranges_reqd)
 
     def test_buildranges_with_clustered_ranges(self):
         """
-        Check that BuildRanges produces clustered ranges when the dataset
+        Check that build_ranges produces clustered ranges when the dataset
         contains clusters.
 
         """
         backend = DistBuildRangesTest.TestBackend()
 
-        # Mock attributes accessed through self. inside BuildRanges
+        # Mock attributes accessed through self. inside build_ranges
         backend.treename = "myTree"
         backend.files = "tests/unit/backend/1000clusters.root"
         backend.nentries = 1000
         npartitions = 1000
 
-        crs = backend.BuildRanges(npartitions)
+        crs = backend.build_ranges(npartitions)
         ranges = rangesToTuples(crs)
 
         start = 0
         end = 1000
         step = 1
 
-        ranges_reqd = [ (a,b) for a,b in zip(range(start, end, step), range(step, end+1, step)) ]
+        ranges_reqd = [(a, b) for a, b in zip(range(start, end, step),
+                                              range(step, end + 1, step))]
 
         self.assertListEqual(ranges, ranges_reqd)
 
     def test_buildranges_with_balanced_ranges(self):
         """
-        Check that BuildRanges produces balanced ranges when there are no
+        Check that build_ranges produces balanced ranges when there are no
         clusters involved.
 
         """
         backend = DistBuildRangesTest.TestBackend()
 
-        # Mock attributes accessed through self. inside BuildRanges
+        # Mock attributes accessed through self. inside build_ranges
         backend.treename = None
         backend.files = None
         backend.nentries = 50
         npartitions = 16
 
-        crs = backend.BuildRanges(npartitions)
+        crs = backend.build_ranges(npartitions)
         ranges = rangesToTuples(crs)
 
         ranges_reqd = [
-            (0,  4) , (4,  8) , (8,  11), (11, 14), (14, 17), (17, 20),
+            (0, 4), (4, 8), (8, 11), (11, 14), (14, 17), (17, 20),
             (20, 23), (23, 26), (26, 29), (29, 32), (32, 35), (35, 38),
             (38, 41), (41, 44), (44, 47), (47, 50)
         ]
 
         self.assertListEqual(ranges, ranges_reqd)
 
+
 class DistRDataFrameInterface(unittest.TestCase):
     """
-    Check `BuildRanges` when instantiating RDataFrame with different parameters
+    Check `build_ranges` when instantiating RDataFrame with different
+    parameters
     """
 
     from PyRDF import current_backend
 
     class TestBackend(Dist):
-        """
-        A Dummy backend class to test the
-        BuildRanges method in Dist class.
-        """
+        """Dummy backend to test the build_ranges method in Dist class."""
+
         def ProcessAndMerge(self, mapper, reducer):
             """
             Dummy implementation of ProcessAndMerge.
@@ -338,11 +346,11 @@ class DistRDataFrameInterface(unittest.TestCase):
             values = [1]
             return values
 
-    def getRangesFromRDF(self, rdf):
+    def get_ranges_from_rdataframe(self, rdf):
         """
-        Common test setup to create ranges out of an RDataFrame head node
+        Common test setup to create ranges out of an RDataFrame instance based
+        on its parameters.
         """
-
         PyRDF.current_backend = DistRDataFrameInterface.TestBackend()
         backend = PyRDF.current_backend
 
@@ -355,7 +363,7 @@ class DistRDataFrameInterface(unittest.TestCase):
         hist.GetValue()
 
         partitions = 2
-        ranges = rangesToTuples(backend.BuildRanges(partitions))
+        ranges = rangesToTuples(backend.build_ranges(partitions))
         return ranges
 
     def test_empty_rdataframe_with_number_of_entries(self):
@@ -366,52 +374,52 @@ class DistRDataFrameInterface(unittest.TestCase):
         """
         rdf = PyRDF.RDataFrame(10)
 
-        ranges = self.getRangesFromRDF(rdf)
-        ranges_reqd = [ (0, 5), (5, 10) ]
+        ranges = self.get_ranges_from_rdataframe(rdf)
+        ranges_reqd = [(0, 5), (5, 10)]
         self.assertListEqual(ranges, ranges_reqd)
 
     def test_rdataframe_with_treename_and_simple_filename(self):
         """
-        Check clustered ranges produced when the dataset is a single ROOT file.
+        Check clustered ranges produced when the input dataset is a single ROOT
+        file.
 
         """
         treename = "myTree"
         filename = "tests/unit/backend/2clusters.root"
         rdf = PyRDF.RDataFrame(treename, filename)
 
-        ranges = self.getRangesFromRDF(rdf)
-        ranges_reqd = [ (0L, 777L), (777L, 1000L) ]
+        ranges = self.get_ranges_from_rdataframe(rdf)
+        ranges_reqd = [(0L, 777L), (777L, 1000L)]
 
         self.assertListEqual(ranges, ranges_reqd)
 
-
     def test_rdataframe_with_treename_and_filename_with_globbing(self):
         """
-        Check clustered ranges produced when the dataset is a single ROOT file
-        with globbing.
+        Check clustered ranges produced when the input dataset is a single ROOT
+        file with globbing.
 
         """
         treename = "myTree"
         filename = "tests/unit/backend/2cluste*.root"
         rdf = PyRDF.RDataFrame(treename, filename)
 
-        ranges = self.getRangesFromRDF(rdf)
-        ranges_reqd = [ (0L, 777L), (777L, 1000L) ]
+        ranges = self.get_ranges_from_rdataframe(rdf)
+        ranges_reqd = [(0L, 777L), (777L, 1000L)]
 
         self.assertListEqual(ranges, ranges_reqd)
 
     def test_rdataframe_with_treename_and_list_of_one_file(self):
         """
-        Check clustered ranges produced when the dataset is a list of a single
-        ROOT file.
+        Check clustered ranges produced when the input dataset is a list of a
+        single ROOT file.
 
         """
         treename = "myTree"
         filelist = ["tests/unit/backend/2clusters.root"]
         rdf = PyRDF.RDataFrame(treename, filelist)
 
-        ranges = self.getRangesFromRDF(rdf)
-        ranges_reqd = [ (0L, 777L), (777L, 1000L) ]
+        ranges = self.get_ranges_from_rdataframe(rdf)
+        ranges_reqd = [(0L, 777L), (777L, 1000L)]
 
         self.assertListEqual(ranges, ranges_reqd)
 
@@ -426,23 +434,27 @@ class DistRDataFrameInterface(unittest.TestCase):
         - 4clusters.root contains 1000 entries split into 4 clusters
             ([0, 249], [250, 499], [500, 749], [750, 999]) being 249, 499, 749
             and 999 inclusive entries
+
         Current mechanism to create clustered ranges takes only into account the
         the number of clusters, it is assumed that clusters inside a ROOT file
-        are properly distributed and balanced with respect to the number of entries.
-        Thus, if a dataset is composed by two ROOT files which are poorly balanced
-        in terms of clusters and entries, the resultant ranges will still respect
-        the cluster boundaries but each one may contain a different number of
+        are properly distributed and balanced with respect to the number of
         entries.
+
+        Thus, if a dataset is composed by two ROOT files which are poorly
+        balanced in terms of clusters and entries, the resultant ranges will
+        still respect the cluster boundaries but each one may contain a
+        different number of entries.
 
         Since this case should not be common, ranges required on this test are
         considered the expected result.
         """
         treename = "myTree"
-        filelist = ["tests/unit/backend/2clusters.root", "tests/unit/backend/4clusters.root"]
+        filelist = ["tests/unit/backend/2clusters.root",
+                    "tests/unit/backend/4clusters.root"]
 
         rdf = PyRDF.RDataFrame(treename, filelist)
 
-        ranges = self.getRangesFromRDF(rdf)
-        ranges_reqd = [ (0L, 1250L), (250L, 1000L) ]
+        ranges = self.get_ranges_from_rdataframe(rdf)
+        ranges_reqd = [(0L, 1250L), (250L, 1000L)]
 
         self.assertListEqual(ranges, ranges_reqd)

--- a/tests/unit/backend/test_local.py
+++ b/tests/unit/backend/test_local.py
@@ -1,100 +1,72 @@
-import PyRDF, unittest, ROOT
+import unittest
+import ROOT
+import PyRDF
 from PyRDF.backend.Local import Local
-from PyRDF.Proxy import Proxy
+
 
 class SelectionTest(unittest.TestCase):
-    """
-    A series of tests to check the
-    accuracy of 'PyRDF.use' method.
-
-    """
+    """Check the accuracy of 'PyRDF.use' method."""
 
     def test_local_select(self):
-        """
-        Test to check if 'local'
-        environment gets set correctly.
-
-        """
-
+        """Check if 'local' environment gets set correctly."""
         PyRDF.use("local")
         self.assertIsInstance(PyRDF.current_backend, Local)
 
+
 class OperationSupportTest(unittest.TestCase):
     """
-    Test cases to ensure that incoming operations are
-    classified accurately in local environments.
+    Ensure that incoming operations are classified accurately in local
+    environments.
 
     """
 
     def test_action(self):
-        """
-        Test case to check that action nodes
-        are classified accurately.
-        """
-
-        # Check in local env
+        """Check that action nodes are classified accurately."""
         backend = Local()
-        op = backend.check_supported("Count")
+        backend.check_supported("Count")
 
     def test_transformation(self):
-        """
-        Test case to check that transformation
-        nodes are classified accurately.
-        """
-
-        # Check in local env
+        """Check that transformation nodes are classified accurately."""
         backend = Local()
-        op = backend.check_supported("Define")
+        backend.check_supported("Define")
 
     def test_unsupported_operations(self):
-        """
-        Test case to check that unsupported operations
-        raise an Exception.
-        """
-
-        # Check in local env
+        """Check that unsupported operations raise an Exception."""
         backend = Local()
         with self.assertRaises(Exception):
-            op = backend.check_supported("Take")
+            backend.check_supported("Take")
 
         with self.assertRaises(Exception):
-            op = backend.check_supported("Snapshot")
+            backend.check_supported("Snapshot")
 
         with self.assertRaises(Exception):
-            op = backend.check_supported("Foreach")
+            backend.check_supported("Foreach")
 
     def test_none(self):
-        """
-        Test case to check that incorrect operations
-        raise an Exception.
-        """
-
-        # Check in local env
+        """Check that incorrect operations raise an Exception."""
         backend = Local()
         with self.assertRaises(Exception):
-            op = backend.check_supported("random")
+            backend.check_supported("random")
 
     def test_range_operation_single_thread(self):
         """
-        Test case to check that 'Range' operation
-        works in single-threaded mode and raises an
+        Check that 'Range' operation works in single-threaded mode and raises an
         Exception in multi-threaded mode.
-        """
 
-        # Check in local env
+        """
         backend = Local()
         backend.check_supported("Range")
 
     def test_range_operation_multi_thread(self):
         """
-        Test case to check that 'Range' operation
-        raises an Exception in multi-threaded mode.
-        """
+        Check that 'Range' operation raises an Exception in multi-threaded
+        mode.
 
+        """
         ROOT.ROOT.EnableImplicitMT()
         backend = Local()
         with self.assertRaises(Exception):
-            op = backend.check_supported("Range")
+            backend.check_supported("Range")
 
         ROOT.ROOT.DisableImplicitMT()
 

--- a/tests/unit/backend/test_local.py
+++ b/tests/unit/backend/test_local.py
@@ -70,20 +70,24 @@ class OperationSupportTest(unittest.TestCase):
 
         ROOT.ROOT.DisableImplicitMT()
 
+
 class InitializationTest(unittest.TestCase):
-    """
-    Check initialization method in the Local backend
+    """Check initialization method in the Local backend"""
 
-    """
     def test_initialization_method(self):
-       # Define a method in the ROOT interpreter called getValue which
-       # returns the value defined by the user on the python side
-       def init(value):
-           cpp_code = '''auto getUserValue = [](){return %s ;};''' % value
-           ROOT.gInterpreter.Declare(cpp_code)
+        """
+        Check initialization method in Local backend.
 
-       PyRDF.initialize(init, 123)
-       PyRDF.current_backend = Local()
-       df = PyRDF.RDataFrame(1)
-       s = df.Define("userValue", "getUserValue()").Sum("userValue")
-       self.assertEqual(s.GetValue(), 123)
+        Define a method in the ROOT interpreter called getValue which returns
+        the value defined by the user on the python side.
+
+        """
+        def init(value):
+            cpp_code = '''auto getUserValue = [](){return %s ;};''' % value
+            ROOT.gInterpreter.Declare(cpp_code)
+
+        PyRDF.initialize(init, 123)
+        PyRDF.current_backend = Local()
+        df = PyRDF.RDataFrame(1)
+        s = df.Define("userValue", "getUserValue()").Sum("userValue")
+        self.assertEqual(s.GetValue(), 123)

--- a/tests/unit/backend/test_spark.py
+++ b/tests/unit/backend/test_spark.py
@@ -1,34 +1,27 @@
-import PyRDF, unittest, ROOT
+import unittest
+import PyRDF
 from PyRDF.backend.Spark import Spark
+from pyspark import SparkContext
+
 
 class SelectionTest(unittest.TestCase):
-    """
-    A series of tests to check the
-    accuracy of 'PyRDF.use' method.
-
-    """
+    """Check the accuracy of 'PyRDF.use' method."""
 
     @classmethod
     def tearDownClass(cls):
         """
-        Cleans up the `SparkContext` objects
-        that were created during the tests in
-        this class.
+        Clean up the `SparkContext` objects that were created during the tests
+        in this class.
 
         """
-        from pyspark import SparkContext
         context = SparkContext.getOrCreate()
         context.stop()
 
     def test_spark_select(self):
-        """
-        Test to check if 'spark'
-        environment gets set correctly.
-
-        """
-
+        """Check if 'spark' environment gets set correctly."""
         PyRDF.use("spark")
         self.assertIsInstance(PyRDF.current_backend, Spark)
+
 
 class SparkBackendInitTest(unittest.TestCase):
     """
@@ -37,26 +30,19 @@ class SparkBackendInitTest(unittest.TestCase):
     input `config` dict.
 
     """
+
     @classmethod
     def tearDown(cls):
-        """
-        Cleans up the `SparkContext` objects
-        that were created.
-
-        """
-        from pyspark import SparkContext
+        """Clean up the `SparkContext` objects that were created."""
         context = SparkContext.getOrCreate()
         context.stop()
 
     def test_set_spark_context_default(self):
         """
-        Test case to check that if the config
-        dictionary is empty, a `SparkContext`
-        object is still created with default
-        options for the current system.
+        Check that if the config dictionary is empty, a `SparkContext`
+        object is still created with default options for the current system.
 
         """
-        from pyspark import SparkContext
         backend = Spark()
 
         self.assertDictEqual(backend.config, {})
@@ -64,138 +50,106 @@ class SparkBackendInitTest(unittest.TestCase):
 
     def test_set_spark_context_with_conf(self):
         """
-        Test case to check that a `SparkContext` object is
-        correctly created for a given `SparkConf` object in
-        the config dictionary.
+        Check that a `SparkContext` object is correctly created for a given
+        `SparkConf` object in the config dictionary.
 
         """
-        from pyspark import SparkContext, SparkConf
-        backend = Spark({'spark.app.name':'my-pyspark-app1'})
+        backend = Spark({'spark.app.name': 'my-pyspark-app1'})
 
         self.assertIsInstance(backend.sparkContext, SparkContext)
-        self.assertEqual(backend.sparkContext.getConf().get('spark.app.name'), 'my-pyspark-app1')
+        appname = backend.sparkContext.getConf().get('spark.app.name')
+        self.assertEqual(appname, 'my-pyspark-app1')
 
     def test_set_npartitions_explicit(self):
         """
-        Test case to check that a `npartitions` is correctly
-        set for a given input value in the config dictionary.
+        Check that the number of partitions is correctly set for a given input
+        value in the config dictionary.
 
         """
-        backend = Spark({"npartitions":5})
-
+        backend = Spark({"npartitions": 5})
         self.assertEqual(backend.npartitions, 5)
 
     def test_npartitions_with_num_executors(self):
         """
-        Test case to check that the value of `npartitions` is correctly set
-        to number of executors when no input value is given in the config
-        dictionary.
+        Check that the number of partitions is correctly set to number of
+        executors when no input value is given in the config dictionary.
 
         """
-        from pyspark import SparkContext, SparkConf
-        backend = Spark({'spark.executor.instances':10})
-
+        backend = Spark({'spark.executor.instances': 10})
         self.assertEqual(backend.npartitions, 10)
 
     def test_npartitions_with_already_existing_spark_context(self):
         """
-        Test case to check that the value of `npartitions` is correctly set
-        when a Spark Context already exists.
+        Check that the number of partitions is correctly set when a Spark
+        Context already exists.
 
         """
-        from pyspark import SparkContext, SparkConf
+        from pyspark import SparkConf
         sparkConf = SparkConf().set('spark.executor.instances', 15)
-        sc = SparkContext(conf=sparkConf)
+        SparkContext(conf=sparkConf)
         backend = Spark()
-
         self.assertEqual(backend.npartitions, 15)
 
     def test_npartitions_default(self):
         """
-        Test case to check that the default value of `npartitions` is
-        correctly set when no input value is given in the config dictionary.
+        Check that the default number of partitions is correctly set when no
+        input value is given in the config dictionary.
 
         """
         backend = Spark()
+        self.assertEqual(backend.npartitions, Spark.MIN_NPARTITIONS)
 
-        self.assertEqual(backend.npartitions, 2)
 
 class OperationSupportTest(unittest.TestCase):
     """
-    Test cases to ensure that incoming operations are
-    classified accurately in distributed environment.
+    Ensure that incoming operations are classified accurately in distributed
+    environment.
 
     """
+
     @classmethod
     def tearDown(cls):
-        """
-        Cleans up the `SparkContext` objects
-        that were created.
-
-        """
-        from pyspark import SparkContext
+        """Clean up the `SparkContext` objects that were created."""
         context = SparkContext.getOrCreate()
         context.stop()
 
     def test_action(self):
-        """
-        Test case to check that action nodes
-        are classified accurately.
-
-        """
-        # Check in Spark env
+        """Check that action nodes are classified accurately."""
         backend = Spark()
-        op = backend.check_supported("Histo1D")
+        backend.check_supported("Histo1D")
 
     def test_transformation(self):
-        """
-        Test case to check that transformation
-        nodes are classified accurately.
-
-        """
-        # Check in Spark env
+        """Check that transformation nodes are classified accurately."""
         backend = Spark()
-        op = backend.check_supported("Define")
+        backend.check_supported("Define")
 
     def test_unsupported_operations(self):
-        """
-        Test case to check that unsupported operations
-        raise an Exception.
-
-        """
-        # Check in Spark env
+        """Check that unsupported operations raise an Exception."""
         backend = Spark()
         with self.assertRaises(Exception):
-            op = backend.check_supported("Take")
+            backend.check_supported("Take")
 
         with self.assertRaises(Exception):
-            op = backend.check_supported("Snapshot")
+            backend.check_supported("Snapshot")
 
         with self.assertRaises(Exception):
-            op = backend.check_supported("Foreach")
+            backend.check_supported("Foreach")
 
         with self.assertRaises(Exception):
-            op = backend.check_supported("Range")
+            backend.check_supported("Range")
 
     def test_none(self):
-        """
-        Test case to check that incorrect operations
-        raise an Exception.
-
-        """
-        # Check in Spark env
+        """Check that incorrect operations raise an Exception."""
         backend = Spark()
         with self.assertRaises(Exception):
-            op = backend.check_supported("random")
+            backend.check_supported("random")
 
     def test_range_operation_single_thread(self):
         """
-        Test case to check that 'Range' operation
-        works in single-threaded mode and raises an
+        Check that 'Range' operation works in single-threaded mode and raises an
         Exception in multi-threaded mode.
 
         """
-       # Check in Spark env
         backend = Spark()
         with self.assertRaises(Exception):
             backend.check_supported("Range")

--- a/tests/unit/backend/test_spark.py
+++ b/tests/unit/backend/test_spark.py
@@ -154,35 +154,40 @@ class OperationSupportTest(unittest.TestCase):
         with self.assertRaises(Exception):
             backend.check_supported("Range")
 
+
 class InitializationTest(unittest.TestCase):
-    """
-    Check initialization method in the Spark backend
+    """Check initialization method in the Spark backend"""
 
-    """
     def test_initialization_method(self):
-       # Define a method in the ROOT interpreter called getValue which
-       # returns the value defined by the user on the python side
-       def init(value):
-           import ROOT
-           cpp_code = '''int userValue = %s ;''' % value
-           ROOT.gInterpreter.ProcessLine(cpp_code)
+        """
+        Check initialization method in Spark backend.
 
-       PyRDF.initialize(init, 123)
-       PyRDF.current_backend = Spark()
-       # Spark backend has a limited list of supported methods, so we use Histo1D
-       # which is a supported action.
-       # The code below creates an RDataFrame instance with one single entry and
-       # defines a column 'u' whose value is taken from the variable 'userValue'.
-       # This variable is only declared inside the ROOT interpreter, however the
-       # value of the variable is passed by the user from the python side.
-       # If the init function defined by the user is properly propagated to the
-       # Spark backend, each workers will run the init function as a first step
-       # and hence the variable 'userValue' will be defined at runtime.
-       # As a result the define operation should read the variable 'userValue'
-       # and assign it to the entries of the column 'u' (only one entry).
-       # Finally, Histo1D returns a histogram filled with one value. The mean
-       # of this single value has to be the value itself, independently of
-       # the number of spawned workers.
-       df = PyRDF.RDataFrame(1).Define("u", "userValue").Histo1D("u")
-       h = df.GetValue()
-       self.assertEqual(h.GetMean(), 123)
+        Define a method in the ROOT interpreter called getValue which returns
+        the value defined by the user on the python side.
+
+        """
+        def init(value):
+            import ROOT
+            cpp_code = '''int userValue = %s ;''' % value
+            ROOT.gInterpreter.ProcessLine(cpp_code)
+
+        PyRDF.initialize(init, 123)
+        PyRDF.current_backend = Spark()
+        # Spark backend has a limited list of supported methods, so we use
+        # Histo1D which is a supported action.
+        # The code below creates an RDataFrame instance with one single entry
+        # and defines a column 'u' whose value is taken from the variable
+        # 'userValue'.
+        # This variable is only declared inside the ROOT interpreter, however
+        # the value of the variable is passed by the user from the python side.
+        # If the init function defined by the user is properly propagated to the
+        # Spark backend, each workers will run the init function as a first step
+        # and hence the variable 'userValue' will be defined at runtime.
+        # As a result the define operation should read the variable 'userValue'
+        # and assign it to the entries of the column 'u' (only one entry).
+        # Finally, Histo1D returns a histogram filled with one value. The mean
+        # of this single value has to be the value itself, independently of
+        # the number of spawned workers.
+        df = PyRDF.RDataFrame(1).Define("u", "userValue").Histo1D("u")
+        h = df.GetValue()
+        self.assertEqual(h.GetMean(), 123)

--- a/tests/unit/test_callable_generator.py
+++ b/tests/unit/test_callable_generator.py
@@ -2,36 +2,40 @@ from PyRDF import CallableGenerator
 from PyRDF.Node import Node
 import unittest
 
-class CallableGeneratorTest(unittest.TestCase):
-    class Temp(object):
-        """
-        A Class for mocking RDF
-        CPP object.
 
-        """
+class CallableGeneratorTest(unittest.TestCase):
+    """
+    Check mechanism to create a callable function that returns a PyROOT object
+    per each PyRDF graph node. This callable takes care of the grape pruning.
+    """
+
+    class Temp(object):
+        """A Class for mocking RDF CPP object."""
 
         def __init__(self):
+            """
+            Creates a mock instance. Each mock method adds an unique number to
+            the `ord_list` so we can check the order in which they were called.
+            """
             self.ord_list = []
 
         def Define(self):
+            """Mock Define method"""
             self.ord_list.append(1)
             return self
 
         def Filter(self):
+            """Mock Filter method"""
             self.ord_list.append(2)
             return self
 
         def Count(self):
+            """Mock Count method"""
             self.ord_list.append(3)
             return self
 
     def test_mapper_from_graph(self):
-        """
-        A simple test case to check
-        the working of mapper.
-
-        """
-
+        """A simple test case to check the working of mapper."""
         # A mock RDF object
         t = CallableGeneratorTest.Temp()
 
@@ -43,7 +47,7 @@ class CallableGeneratorTest(unittest.TestCase):
         n2 = node.Filter().Filter()
         n4 = n2.Count()
         n5 = n1.Count()
-        n6 = node.Filter()
+        n6 = node.Filter()  # noqa: avoid PEP8 F841
 
         # Generate and execute the mapper
         generator = CallableGenerator(node)
@@ -53,19 +57,16 @@ class CallableGeneratorTest(unittest.TestCase):
 
         reqd_order = [1, 3, 2, 2, 3, 2]
 
-        # Assertions
         self.assertEqual(t.ord_list, reqd_order)
         self.assertListEqual(nodes, [n5.action_node, n4.action_node])
         self.assertListEqual(values, [t, t])
 
     def test_mapper_with_pruning(self):
         """
-        A test case to check that the
-        mapper works even in the case
-        of pruning.
+        A test case to check that the mapper works even in the case of
+        pruning.
 
         """
-
         # A mock RDF object
         t = CallableGeneratorTest.Temp()
 
@@ -77,9 +78,10 @@ class CallableGeneratorTest(unittest.TestCase):
         n2 = node.Filter().Filter()
         n4 = n2.Count()
         n5 = n1.Count()
-        n6 = node.Filter()
+        n6 = node.Filter()  # noqa: avoid PEP8 F841
 
-        n5 = n1.Filter() # Reason for pruning (change of reference)
+        # Reason for pruning (change of reference)
+        n5 = n1.Filter()  # noqa: avoid PEP8 F841
 
         # Generate and execute the mapper
         generator = CallableGenerator(node)
@@ -89,7 +91,6 @@ class CallableGeneratorTest(unittest.TestCase):
 
         reqd_order = [1, 2, 2, 2, 3, 2]
 
-        # Assertions
         self.assertEqual(t.ord_list, reqd_order)
         self.assertListEqual(nodes, [n4.action_node])
         self.assertListEqual(values, [t])

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -2,126 +2,94 @@ from PyRDF.Node import Node
 from PyRDF.Proxy import Proxy
 import unittest
 
+
 class OperationReadTest(unittest.TestCase):
     """
-    A series of test cases to check that
-    all new operations are created properly
+    A series of test cases to check that all new operations are created properly
     inside a new node.
-
     """
 
     def test_attr_read(self):
-        """
-        Test case to check that
-        function names are read
-        accurately.
-
-        """
-
+        """Function names are read accurately."""
         node = Node(None, None)
-        func = node.Define
+        func = node.Define  # noqa: avoid PEP8 F841
         self.assertEqual(node._cur_attr, "Define")
 
     def test_args_read(self):
-        """
-        Test case to check that
-        arguments (unnamed) are
-        read accurately.
-
-        """
-
+        """Arguments (unnamed) are read accurately."""
         node = Node(None, None)
         newNode = node.Define(1, "b", a="1", b=2)
         self.assertEqual(newNode.operation.args, (1, "b"))
 
     def test_kwargs_read(self):
-        """
-        Test case to check that
-        named arguments are
-        read accurately.
-
-        """
-
+        """Named arguments are read accurately."""
         node = Node(None, None)
         newNode = node.Define(1, "b", a="1", b=2)
-        self.assertEqual(newNode.operation.kwargs, {"a":"1", "b":2})
+        self.assertEqual(newNode.operation.kwargs, {"a": "1", "b": 2})
+
 
 class NodeReturnTest(unittest.TestCase):
     """
-    A series of test cases to check that
-    right objects are returned for a node
+    A series of test cases to check that right objects are returned for a node
     (Proxy or Node).
 
     """
 
     def test_proxy_return(self):
-        """
-        Test case to check that
-        Proxy objects are returned
-        for action nodes.
-
-        """
-
+        """Proxy objects are returned for action nodes."""
         node = Node(None, None)
         newNode = node.Count()
         self.assertIsInstance(newNode, Proxy)
 
     def test_transformation_return(self):
-        """
-        Test case to check that
-        Node objects are returned
-        for transformation nodes.
-
-        """
-
+        """Node objects are returned for transformation nodes."""
         node = Node(None, None)
         newNode = node.Define(1)
         self.assertIsInstance(newNode, Node)
 
+
 class DfsTest(unittest.TestCase):
     """
-    A series of test cases to check
-    that the nodes are traversed in
-    the right order for various
-    combination of operations.
+    A series of test cases to check that the nodes are traversed in
+    the right order for various combination of operations.
 
     """
 
     class Temp(object):
-        """
-        A Class for mocking RDF CPP object.
-
-        """
+        """A Class for mocking RDF CPP object."""
 
         def __init__(self):
+            """
+            Creates a mock instance. Each mock method adds an unique number to
+            the `ord_list` so we can check the order in which they were called.
+            """
             self.ord_list = []
 
         def Define(self):
+            """Mock Define method"""
             self.ord_list.append(1)
             return self
 
         def Filter(self):
+            """Mock Filter method"""
             self.ord_list.append(2)
             return self
 
         def Count(self):
+            """Mock Count method"""
             self.ord_list.append(3)
             return self
 
     @classmethod
-    def traverse(cls, node, prev_object= None):
-        """
-        Method to do a depth-first traversal of
-        the graph from the root.
-
-        """
+    def traverse(cls, node, prev_object=None):
+        """Method to do a depth-first traversal of the graph from the root."""
         if not node.operation:
             prev_object = DfsTest.Temp()
             node.value = prev_object
             node.graph_prune()
 
         else:
-            ## Execution of the node
+            # Execution of the node
             op = getattr(prev_object, node.operation.name)
             node.value = op(*node.operation.args, **node.operation.kwargs)
 
@@ -130,14 +98,12 @@ class DfsTest(unittest.TestCase):
 
         return prev_object.ord_list
 
-
     def test_dfs_graph_with_pruning_actions(self):
         """
-        Test case to check that action nodes with
-        no user references get pruned.
+        Test case to check that action nodes with no user references get
+        pruned.
 
         """
-
         # Head node
         node = Node(None, None)
 
@@ -145,14 +111,14 @@ class DfsTest(unittest.TestCase):
         n1 = node.Define()
         n2 = node.Filter()
         n3 = n2.Filter()
-        n4 = n3.Count()
+        n4 = n3.Count()  # noqa: avoid PEP8 F841
         n5 = n1.Count()
-        n6 = node.Filter()
+        n6 = node.Filter()  # noqa: avoid PEP8 F841
 
-        # Action pruning
-        n5 = n1.Filter() # n5 was an action node earlier
+        # Action pruning, n5 was an action node earlier
+        n5 = n1.Filter()  # noqa: avoid PEP8 F841
 
-        obtained_order = DfsTest.traverse(node = node.get_head())
+        obtained_order = DfsTest.traverse(node=node.get_head())
 
         reqd_order = [1, 2, 2, 2, 3, 2]
 
@@ -160,11 +126,10 @@ class DfsTest(unittest.TestCase):
 
     def test_dfs_graph_with_pruning_transformations(self):
         """
-        Test case to check that transformation nodes with
-        no children and no user references get pruned.
+        Test case to check that transformation nodes with no children and
+        no user references get pruned.
 
         """
-
         # Head node
         node = Node(None, None)
 
@@ -172,14 +137,14 @@ class DfsTest(unittest.TestCase):
         n1 = node.Define()
         n2 = node.Filter()
         n3 = n2.Filter()
-        n4 = n3.Count()
-        n5 = n1.Filter()
-        n6 = node.Filter()
+        n4 = n3.Count()  # noqa: avoid PEP8 F841
+        n5 = n1.Filter()  # noqa: avoid PEP8 F841
+        n6 = node.Filter()  # noqa: avoid PEP8 F841
 
-        # Transformation pruning
-        n5 = n1.Count() # n5 was earlier a transformation node
+        # Transformation pruning, n5 was earlier a transformation node
+        n5 = n1.Count()  # noqa: avoid PEP8 F841
 
-        obtained_order = DfsTest.traverse(node = node.get_head())
+        obtained_order = DfsTest.traverse(node=node.get_head())
 
         reqd_order = [1, 3, 2, 2, 3, 2]
 
@@ -187,12 +152,9 @@ class DfsTest(unittest.TestCase):
 
     def test_dfs_graph_with_recursive_pruning(self):
         """
-        Test case to check that nodes in a PyRDF
-        graph with no user references and no children
-        get pruned recursively.
-
+        Test case to check that nodes in a PyRDF graph with no user references
+        and no children get pruned recursively.
         """
-
         # Head node
         node = Node(None, None)
 
@@ -200,14 +162,14 @@ class DfsTest(unittest.TestCase):
         n1 = node.Define()
         n2 = node.Filter()
         n3 = n2.Filter()
-        n4 = n3.Count()
-        n5 = n1.Filter()
-        n6 = node.Filter()
+        n4 = n3.Count()  # noqa: avoid PEP8 F841
+        n5 = n1.Filter()  # noqa: avoid PEP8 F841
+        n6 = node.Filter()  # noqa: avoid PEP8 F841
 
         # Remove references from n4 and it's parent nodes
-        n4 = n3 = n2 = None
+        n4 = n3 = n2 = None  # noqa: avoid PEP8 F841
 
-        obtained_order = DfsTest.traverse(node = node.get_head())
+        obtained_order = DfsTest.traverse(node=node.get_head())
 
         reqd_order = [1, 2, 2]
 
@@ -215,11 +177,10 @@ class DfsTest(unittest.TestCase):
 
     def test_dfs_graph_with_parent_pruning(self):
         """
-        Test case to check that parent nodes with
-        no user references don't get pruned.
+        Test case to check that parent nodes with no user references don't
+        get pruned.
 
         """
-
         # Head node
         node = Node(None, None)
 
@@ -227,14 +188,14 @@ class DfsTest(unittest.TestCase):
         n1 = node.Define()
         n2 = node.Filter()
         n3 = n2.Filter()
-        n4 = n3.Count()
-        n5 = n1.Filter()
-        n6 = node.Filter()
+        n4 = n3.Count()  # noqa: avoid PEP8 F841
+        n5 = n1.Filter()  # noqa: avoid PEP8 F841
+        n6 = node.Filter()  # noqa: avoid PEP8 F841
 
         # Remove references from n2 (which shouldn't affect the graph)
         n2 = None
 
-        obtained_order = DfsTest.traverse(node = node.get_head())
+        obtained_order = DfsTest.traverse(node=node.get_head())
 
         reqd_order = [1, 2, 2, 2, 3, 2]
         # Removing references from n2 will not prune any node
@@ -244,8 +205,10 @@ class DfsTest(unittest.TestCase):
 
     def test_dfs_graph_with_computed_values_pruning(self):
         """
-        """
+        Test case to check that computed values in action nodes get
+        pruned.
 
+        """
         # Head node
         node = Node(None, None)
 
@@ -253,7 +216,7 @@ class DfsTest(unittest.TestCase):
         n1 = node.Define()
         n2 = node.Filter()
         n3 = n2.Filter()
-        n4 = n3.Count()
+        n4 = n3.Count()  # noqa: avoid PEP8 F841
         n5 = n1.Filter()
         n6 = n5.Count()
         n7 = node.Filter()
@@ -264,9 +227,9 @@ class DfsTest(unittest.TestCase):
         # This is to make sure that transformation
         # leaf nodes with value (possibly set intentionally)
         # don't get pruned.
-        n7.value = 1
+        n7.value = 1  # noqa: avoid PEP8 F841
 
-        obtained_order = DfsTest.traverse(node = node.get_head())
+        obtained_order = DfsTest.traverse(node=node.get_head())
 
         # The node 'n6' will be pruned. Hence,
         # there's only one '3' in this list.
@@ -276,12 +239,10 @@ class DfsTest(unittest.TestCase):
 
     def test_dfs_graph_without_pruning(self):
         """
-        Test case to check that node pruning does not
-        occur if every node either has children or some
-        user references.
+        Test case to check that node pruning does not occur if every node either
+        has children or some user references.
 
         """
-
         # Head node
         node = Node(None, None)
 
@@ -289,39 +250,40 @@ class DfsTest(unittest.TestCase):
         n1 = node.Define()
         n2 = node.Filter()
         n3 = n2.Filter()
-        n4 = n3.Count()
-        n5 = n1.Count()
-        n6 = node.Filter()
+        n4 = n3.Count()  # noqa: avoid PEP8 F841
+        n5 = n1.Count()  # noqa: avoid PEP8 F841
+        n6 = node.Filter()  # noqa: avoid PEP8 F841
 
-        obtained_order = DfsTest.traverse(node = node.get_head())
+        obtained_order = DfsTest.traverse(node=node.get_head())
 
         reqd_order = [1, 3, 2, 2, 3, 2]
 
         self.assertEqual(obtained_order, reqd_order)
 
+
 class DunderMethodsTest(unittest.TestCase):
     """
-    Test cases to check the response of
-    the Node class for various dunder
+    Test cases to check the response of the Node class for various dunder
     method calls.
 
     """
+
     def test_get_state(self):
         """
-        Test cases to check the working of
-        __getstate__ method on Node class.
+        Test cases to check the working of __getstate__ method on
+        Node class.
 
         """
-        node = Node(None, None) # Head node
-        n1 = node.Define("a", b="c") # First child node
+        node = Node(None, None)  # Head node
+        n1 = node.Define("a", b="c")  # First child node
 
         # Required dictionaries
-        node_dict = {"children":[n1]}
+        node_dict = {"children": [n1]}
         n1_dict = {
-        'operation_name':"Define",
-        'operation_args':("a",),
-        'operation_kwargs':{"b":"c"},
-        'children':[]
+            'operation_name': "Define",
+            'operation_args': ("a",),
+            'operation_kwargs': {"b": "c"},
+            'children': []
         }
 
         self.assertDictEqual(node.__getstate__(), node_dict)
@@ -333,39 +295,42 @@ class DunderMethodsTest(unittest.TestCase):
         __setstate__ method on Node class.
 
         """
-        node = Node(None, None) # Head node
-        n1 = Node(None, None) # First child node
+        node = Node(None, None)  # Head node
+        n1 = Node(None, None)  # First child node
 
         # State dictionaries
-        node_dict = {"children":[n1]}
+        node_dict = {"children": [n1]}
         n1_dict = {
-        'operation_name':"Define",
-        'operation_args':("a",),
-        'operation_kwargs':{"b":"c"},
-        'children':[]
+            'operation_name': "Define",
+            'operation_args': ("a",),
+            'operation_kwargs': {"b": "c"},
+            'children': []
         }
 
         # Set node objects with state dicts
         node.__setstate__(node_dict)
         n1.__setstate__(n1_dict)
 
-        self.assertListEqual([node.operation, node.children], [None, node_dict["children"]])
-        self.assertListEqual([
-            n1.operation.name,
-            n1.operation.args,
-            n1.operation.kwargs,
-            n1.children
+        self.assertListEqual([node.operation, node.children],
+                             [None, node_dict["children"]])
+        self.assertListEqual(
+            [
+                n1.operation.name,
+                n1.operation.args,
+                n1.operation.kwargs,
+                n1.children
             ], [
-            n1_dict["operation_name"],
-            n1_dict["operation_args"],
-            n1_dict["operation_kwargs"],
-            n1_dict["children"]
-            ])
+                n1_dict["operation_name"],
+                n1_dict["operation_args"],
+                n1_dict["operation_kwargs"],
+                n1_dict["children"]
+            ]
+        )
 
     def test_other_dunder_methods(self):
         """
-        Test cases to check the working of
-        other dunder methods on Node class.
+        Test cases to check the working of other dunder methods on
+        Node class.
 
         """
         node = Node(None, None)
@@ -374,32 +339,31 @@ class DunderMethodsTest(unittest.TestCase):
         node.__format__('')
 
         with self.assertRaises(AttributeError):
-            node.__random__() # Unknown dunder method
+            node.__random__()  # Unknown dunder method
+
 
 class PickleTest(unittest.TestCase):
-    """
-    Tests to check the pickling an un-pickling of
-    Node instances.
+    """Tests to check the pickling an un-pickling of Node instances."""
 
-    """
     def assertGraphs(self, current_node1, current_node2):
         """
-        Asserts every node in the given graphs starting
-        from the given head nodes.
+        Asserts every node in the given graphs starting from the given
+        head nodes.
 
         """
-        self.assertNodes(current_node1, current_node2) # Equality between nodes
+        self.assertNodes(current_node1, current_node2)  # Equality between nodes
 
         for n1, n2 in zip(current_node1.children, current_node2.children):
-            self.assertGraphs(n1, n2) # Check the rest of the graphs
+            self.assertGraphs(n1, n2)  # Check the rest of the graphs
 
     def assertNodes(self, node1, node2):
         """
-        Assert equality between two given nodes by checking
-        the operation and number of children nodes.
+        Assert equality between two given nodes by checking the operation and
+        number of children nodes.
 
         """
-        self.assertEqual(len(node1.children), len(node2.children)) # Check the number of children
+        # Check the number of children
+        self.assertEqual(len(node1.children), len(node2.children))
 
         # Assert operations
         if not node1.operation:
@@ -418,11 +382,11 @@ class PickleTest(unittest.TestCase):
         import pickle
 
         # Node definitions
-        node = Node(None, None) # Head node
-        n1 = node.Define("a", b="c") # First child node
-        n2 = n1.Count()
+        node = Node(None, None)  # Head node
+        n1 = node.Define("a", b="c")  # First child node
+        n2 = n1.Count()  # noqa: avoid PEP8 F841
         n3 = node.Filter("b")
-        n4 = n3.Count()
+        n4 = n3.Count()  # noqa: avoid PEP8 F841
 
         # Pickled representation of nodes
         pickled_node = pickle.dumps(node)

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -1,103 +1,54 @@
 from PyRDF.Operation import Operation
 import unittest
 
-class ClassifyTest(unittest.TestCase):
-    """
-    Test cases to ensure that incoming
-    operations are classified accurately.
 
-    """
+class ClassifyTest(unittest.TestCase):
+    """Ensure that incoming operations are classified accurately."""
 
     def test_action(self):
-        """
-        Test case to check that action nodes
-        are classified accurately.
-
-        """
-
+        """Action nodes are classified accurately."""
         op = Operation("Count")
         self.assertEqual(op.op_type, Operation.Types.ACTION)
 
     def test_instant_action(self):
-        """
-        Test case to check that instant
-        actions are classified accurately.
-
-        """
+        """Instant actions are classified accurately."""
         op = Operation("Snapshot")
         self.assertEqual(op.op_type, Operation.Types.INSTANT_ACTION)
 
     def test_transformation(self):
-        """
-        Test case to check that transformation
-        nodes are classified accurately.
-
-        """
-
+        """Transformation nodes are classified accurately."""
         op = Operation("Define", "c1")
         self.assertEqual(op.op_type, Operation.Types.TRANSFORMATION)
 
     def test_none(self):
-        """
-        Test case to check that incorrect operations
-        raise an Exception.
-
-        """
-
+        """Incorrect operations raise an Exception."""
         with self.assertRaises(Exception):
-            op = Operation("random")
+            Operation("random")
+
 
 class ArgsTest(unittest.TestCase):
-    """
-    Test cases to ensure that arguments
-    and named arguments are set accurately.
-
-    """
+    """Ensure that arguments and named arguments are set accurately."""
 
     def test_without_kwargs(self):
-        """
-        Test case to check accuracy of
-        all arguments with no named
-        arguments as input.
-
-        """
-
+        """Check that unnamed arguments are properly set."""
         op = Operation("Define", 1, "b")
         self.assertEqual(op.args, (1, "b"))
         self.assertEqual(op.kwargs, {})
 
     def test_without_args(self):
-        """
-        Test case to check accuracy of
-        all arguments with no unnamed
-        arguments as input.
-
-        """
-
+        """Check that no unnamed arguments are properly set."""
         op = Operation("Define", a=1, b="b")
         self.assertEqual(op.args, ())
-        self.assertEqual(op.kwargs, {"a":1, "b":"b"})
+        self.assertEqual(op.kwargs, {"a": 1, "b": "b"})
 
     def test_with_args_and_kwargs(self):
-        """
-        Test case to check accuracy of
-        all arguments with both named and
-        unnamed arguments in the input.
-
-        """
-
+        """Check that named and unnamed arguments are properly set."""
         op = Operation("Define", 2, "p", a=1, b="b")
         self.assertEqual(op.args, (2, "p"))
-        self.assertEqual(op.kwargs, {"a":1, "b":"b"})
+        self.assertEqual(op.kwargs, {"a": 1, "b": "b"})
 
     def test_without_args_and_kwargs(self):
-        """
-        Test case to check accuracy of
-        all arguments with no arguments
-        at all in the input.
-
-        """
-
+        """Check Operation constructor without arguments."""
         op = Operation("Define")
         self.assertEqual(op.args, ())
         self.assertEqual(op.kwargs, {})

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -2,50 +2,35 @@ from PyRDF.Proxy import Proxy
 from PyRDF.Node import Node
 from PyRDF.backend.Backend import Backend
 from PyRDF import RDataFrame
-import unittest, PyRDF
+import unittest
+import PyRDF
+
 
 class AttrReadTest(unittest.TestCase):
-    """
-    Test cases to check working of
-    methods in Proxy class.
-
-    """
+    """Test Proxy class methods."""
 
     class Temp(object):
-        """
-        A mock action node result class.
+        """A mock action node result class."""
 
-        """
         def val(self, arg):
-            """
-            A test method to check function
-            call on the Temp class.
-
-            """
-            return arg+123 # A simple operation to check
+            """A test method to check function call on the Temp class."""
+            return arg + 123  # A simple operation to check
 
     def test_attr_simple(self):
-        """
-        Test case to check that a Proxy
-        object reads the right input
-        attribute.
-
-        """
-
+        """Proxy object reads the right input attribute."""
         node = Node(None, None)
         proxy = Proxy(node)
         func = proxy.attr
 
         self.assertEqual(proxy._cur_attr, "attr")
+        self.assertTrue(callable(func))
 
     def test_return_value(self):
         """
-        Test case to check that a Proxy
-        object computes and returns the
-        right output based on the function call.
+        Proxy object computes and returns the right output based on the
+        function call.
 
         """
-
         t = AttrReadTest.Temp()
         node = Node(None, None)
         node.value = t
@@ -53,18 +38,17 @@ class AttrReadTest(unittest.TestCase):
 
         self.assertEqual(proxy.val(21), 144)
 
-class GetValueTests(unittest.TestCase):
-    """
-    Test cases to check the working of
-    'GetValue' instance method in Proxy.
 
-    """
+class GetValueTests(unittest.TestCase):
+    """Check 'GetValue' instance method in Proxy."""
+
     class TestBackend(Backend):
         """
-        Test backend to verify the working of
-        'GetValue' instance method in Proxy.
+        Test backend to verify the working of 'GetValue' instance method
+        in Proxy.
 
         """
+
         def execute(self, generator):
             """
             Test implementation of the execute method

--- a/tests/unit/test_rdataframe.py
+++ b/tests/unit/test_rdataframe.py
@@ -1,13 +1,11 @@
-import unittest, ROOT
-from PyRDF import RDataFrame, RDataFrameException
+import unittest
+import ROOT
+from PyRDF import RDataFrame
+from PyRDF import RDataFrameException
+
 
 class RDataFrameConstructorTests(unittest.TestCase):
-    """
-    Tests to check the working of
-    various constructors of PyRDF's
-    RDataFrame
-
-    """
+    """Check various constructors of PyRDF's RDataFrame"""
 
     def assertArgs(self, args_list1, args_list2):
         """
@@ -26,26 +24,14 @@ class RDataFrameConstructorTests(unittest.TestCase):
             # Check the contents
             self.assertListEqual(list(elem1), list(elem2))
 
-
     def test_integer_arg(self):
-        """
-        Test case to check the
-        working of a single
-        integer argument
-        (one argument constructor)
-
-        """
+        """Constructor with number of entries"""
         RDF = RDataFrame(10)
 
         self.assertListEqual(RDF.args, [10])
 
     def test_two_args(self):
-        """
-        Test cases to check the
-        working of the two
-        argument contructor
-
-        """
+        """Constructor with list of input files"""
         rdf_2_files = ["file1.root", "file2.root"]
 
         # Convert RDF files list to ROOT CPP vector
@@ -67,14 +53,7 @@ class RDataFrameConstructorTests(unittest.TestCase):
         self.assertArgs(RDF_3.args, ["treename", reqd_vec])
 
     def test_three_args_with_single_file(self):
-        """
-        Test cases to check the
-        working of the three
-        argument contructor
-        with the second argument
-        as a string
-
-        """
+        """Constructor with TTree, one input file and selected branches"""
         rdf_branches = ["branch1", "branch2"]
 
         # Convert RDF branches list to ROOT CPP Vector
@@ -92,15 +71,7 @@ class RDataFrameConstructorTests(unittest.TestCase):
         self.assertArgs(RDF_2.args, ["treename", "file.root", reqd_vec])
 
     def test_three_args_with_multiple_files(self):
-        """
-        Test cases to check the
-        working of the three
-        argument contructor
-        with the second argument
-        as a List or a Vector
-        of strings
-
-        """
+        """Constructor with TTree, list of input files and selected branches"""
         rdf_branches = ["branch1", "branch2"]
         rdf_files = ["file1.root", "file2.root"]
 
@@ -137,60 +108,45 @@ class RDataFrameConstructorTests(unittest.TestCase):
         self.assertArgs(RDF_4.args, reqd_args_list)
 
     def test_incorrect_args(self):
-        """
-        Test cases to check the
-        exceptions raised for
-        incorrect arguments
-
-        """
+        """Constructor with incorrect arguments"""
         with self.assertRaises(RDataFrameException):
             # Incorrect first argument in 2-argument case
-            RDF = RDataFrame(10, "file.root")
+            RDataFrame(10, "file.root")
 
         with self.assertRaises(RDataFrameException):
             # Incorrect third argument in 3-argument case
-            RDF = RDataFrame("treename", "file.root", "column1")
+            RDataFrame("treename", "file.root", "column1")
 
         with self.assertRaises(RDataFrameException):
             # No argument case
-            RDF = RDataFrame()
+            RDataFrame()
+
 
 class NumEntriesTest(unittest.TestCase):
-    """
-    Test cases to ensure that the backend
-    method 'get_num_entries' returns the
-    number of entries in the given dataset
-    accurately.
+    """'get_num_entries' returns the number of entries in the input dataset"""
 
-    """
     def fill_tree(self, size):
-        """
-        Stores a RDataFrame object of given
-        size in 'data.root'.
-
-        """
+        """Stores an RDataFrame object of a given size in 'data.root'."""
         tdf = ROOT.ROOT.RDataFrame(size)
         tdf.Define("b1", "(double) tdfentry_").Snapshot("tree", "data.root")
 
     def test_num_entries_single_arg_case(self):
         """
-        Test case to ensure that the number of
-        entries recorded are correct in the case
+        Ensure that the number of entries recorded are correct in the case
         of a single integer argument to RDataFrame.
 
         """
-        rdf = RDataFrame(123) # Create RDataFrame instance
+        rdf = RDataFrame(123)  # Create RDataFrame instance
 
         self.assertEqual(rdf.get_num_entries(), 123)
 
     def test_num_entries_two_args_case(self):
         """
-        Test cases to ensure that the number of
-        entries recorded are correct in the case
+        Ensure that the number of entries recorded are correct in the case
         of two arguments to RDataFrame constructor.
 
         """
-        self.fill_tree(1111) # Store RDataFrame object of size 1111
+        self.fill_tree(1111)  # Store RDataFrame object of size 1111
         files_vec = ROOT.std.vector('string')()
         files_vec.push_back("data.root")
 
@@ -205,12 +161,11 @@ class NumEntriesTest(unittest.TestCase):
 
     def test_num_entries_three_args_case(self):
         """
-        Test cases to ensure that the number of
-        entries recorded are correct in the case
+        Ensure that the number of entries recorded are correct in the case
         of two arguments to RDataFrame constructor.
 
         """
-        self.fill_tree(1234) # Store RDataFrame object of size 1234
+        self.fill_tree(1234)  # Store RDataFrame object of size 1234
         branches_vec_1 = ROOT.std.vector('string')()
         branches_vec_2 = ROOT.std.vector('string')()
         branches_vec_1.push_back("b1")
@@ -229,12 +184,11 @@ class NumEntriesTest(unittest.TestCase):
 
     def test_num_entries_with_ttree_arg(self):
         """
-        Test cases to ensure that the number of
-        entries recorded are correct in the case
+        Ensure that the number of entries recorded are correct in the case
         of RDataFrame constructor with a TTree.
 
         """
-        tree = ROOT.TTree("tree", "test") # Create tree
+        tree = ROOT.TTree("tree", "test")  # Create tree
         tree.Branch("x", 1)
         tree.Branch("y", 2)
         num_entries = 4


### PR DESCRIPTION
The purpose of this PR is to establish a common code style and format so new contributions follow the same rules. [PEP8](https://www.python.org/dev/peps/pep-0008/) is the chosen style guide. More in detail this PR:

- Add PEP8 style to the code base, excluding `tutorials` as they are taken from the ROOT repo as they are.
- Add a `flake8.cfg` configuration file to exclude some PEP8 rules.
- Reduce verbosity of some doc strings
- Add missing doc strings
- Apply naming conventions (i.e. replace `BuildRange` with `build_range`)
- Add some refactoring to allow a better style
- Replace `tdf` by `rdf`
- Add a TravisCI job to check the syntax on every PR  
