### PR TITLE
Add call to the initialization method on the current user session

### DIFF
--- a/PyRDF/__init__.py
+++ b/PyRDF/__init__.py
@@ -65,7 +65,8 @@ def include(includes_list):
 def initialize(fun, *args, **kwargs):
     """
     Set a function that will be executed as a first step on every backend before
-    any other operation.
+    any other operation. This method also executes the function on the current
+    user environment so changes are visible on the running session.
 
     This allows users to inject and execute custom code on the worker
     environment without being part of the RDataFrame computational graph.

--- a/PyRDF/backend/Backend.py
+++ b/PyRDF/backend/Backend.py
@@ -81,6 +81,7 @@ class Backend(ABC):
 
         """
         cls.initialization = functools.partial(fun, *args, **kwargs)
+        fun(*args, **kwargs)
 
     def check_supported(self, operation_name):
         """

--- a/tests/unit/backend/test_common.py
+++ b/tests/unit/backend/test_common.py
@@ -114,3 +114,17 @@ class InitializationTest(unittest.TestCase):
         PyRDF.initialize(returnNumber, 123)
         f = PyRDF.current_backend.initialization
         self.assertEqual(f(), 123)
+
+    def test_initialization_runs_in_current_environment(self):
+        """
+        User initialization method should be executed on the current user
+        session, so actions applied by the user initialization function are
+        also visible in the current scenario.
+        """
+        def defineIntVariable(name, value):
+            import ROOT
+            ROOT.gInterpreter.ProcessLine("int %s = %s;" % (name, value))
+
+        varvalue = 2
+        PyRDF.initialize(defineIntVariable, "myInt", varvalue)
+        self.assertEqual(ROOT.myInt, varvalue)


### PR DESCRIPTION
The initialize method is a mechanism to setup the environment on the distributed workers without using the RDataFrame computation graph. However, users will likely make use of variables and functions defined by this initialization method on their analysis, so they need to be also declared on the current user session.

This PR adds a call to the user initialization function so changes are also visible on the current environment. This call happens on the Backend internal class but it is announced to users on the docstring of the API method PyRDF.initialize, which is the only one they should be calling to.

This PR also adds a test to check this behaviour.