### PR TITLE
Declare headers on the current session

### DIFF
--- a/.travis-unit-script.sh
+++ b/.travis-unit-script.sh
@@ -23,6 +23,7 @@ python setup.py install --user
 # -x exit instantly on first error or failed test
 # -v increase verbosity
 pytest -x -v
+check_error $? "pytest"
 
 # Run tutorials
 echo " ======== Running single-threaded tutorials ======== "

--- a/PyRDF/__init__.py
+++ b/PyRDF/__init__.py
@@ -3,6 +3,7 @@ from .RDataFrame import RDataFrameException  # noqa
 from .CallableGenerator import CallableGenerator  # noqa
 from backend.Local import Local
 from backend.Backend import Backend
+from backend.Utils import Utils
 
 current_backend = Local()
 includes = []
@@ -44,13 +45,13 @@ def use(backend_name, conf={}):
 
 def include(includes_list):
     """
-    Includes a list of C++ headers to be declared before execution.
+    Includes a list of C++ headers to be declared before execution. Each
+    header is also declared on the current running session.
 
     parameters
     ----------
     includes_list : list or str
-        This list should consist of all necessary C++
-        headers as strings.
+        This list should consist of all necessary C++ headers as strings.
 
     """
     global current_backend, includes
@@ -60,6 +61,7 @@ def include(includes_list):
         includes_list = [includes_list]
 
     includes.extend(includes_list)
+    Utils.declare_headers(includes_list)
 
 
 def initialize(fun, *args, **kwargs):

--- a/PyRDF/backend/Local.py
+++ b/PyRDF/backend/Local.py
@@ -1,6 +1,5 @@
 import ROOT
 from .Backend import Backend
-from .Utils import Utils
 
 
 class Local(Backend):
@@ -57,14 +56,7 @@ class Local(Backend):
             responsible for generating the callable function.
 
         """
-        from .. import includes
-
         mapper = generator.get_callable()  # Get the callable
-
-        Utils.declare_headers(includes)  # Declare headers if any
-
-        # Run initialization method to prepare the worker runtime environment
-        Backend.initialization()
 
         if not self.pyroot_rdf:
             self.pyroot_rdf = ROOT.ROOT.RDataFrame(*generator.head_node.args)

--- a/tests/unit/backend/test_common.py
+++ b/tests/unit/backend/test_common.py
@@ -94,10 +94,10 @@ class DeclareHeadersTest(unittest.TestCase):
 
     def test_multiple_headers_declare(self):
         """'declare_headers' with multiple headers to be included."""
-        Utils.declare_headers(["tests/unit/backend/test_headers/header1.hxx",
-                               "tests/unit/backend/test_headers/header2.hxx"])
+        Utils.declare_headers(["tests/unit/backend/test_headers/header2.hxx",
+                               "tests/unit/backend/test_headers/header3.hxx"])
 
-        self.assertEqual(ROOT.f(1), True)
+        self.assertEqual(ROOT.a(1), True)
         self.assertEqual(ROOT.f1(2), 2)
         self.assertEqual(ROOT.f2("myString"), "myString")
 
@@ -106,9 +106,9 @@ class DeclareHeadersTest(unittest.TestCase):
         # Before the header declaration the function f is not present on the
         # ROOT interpreter
         with self.assertRaises(AttributeError):
-            self.assertRaises(ROOT.f(1))
-        PyRDF.include("tests/unit/backend/test_headers/header1.hxx")
-        self.assertEqual(ROOT.f(1), True)
+            self.assertRaises(ROOT.b(1))
+        PyRDF.include("tests/unit/backend/test_headers/header4.hxx")
+        self.assertEqual(ROOT.b(1), True)
 
 
 class InitializationTest(unittest.TestCase):

--- a/tests/unit/backend/test_common.py
+++ b/tests/unit/backend/test_common.py
@@ -98,6 +98,15 @@ class DeclareHeadersTest(unittest.TestCase):
         self.assertEqual(ROOT.f1(2), 2)
         self.assertEqual(ROOT.f2("myString"), "myString")
 
+    def test_header_declaration_on_current_session(self):
+        """Header has to be declared on the current session"""
+        # Before the header declaration the function f is not present on the
+        # ROOT interpreter
+        with self.assertRaises(AttributeError):
+            self.assertRaises(ROOT.f(1))
+        PyRDF.include("tests/unit/backend/test_headers/header1.hxx")
+        self.assertEqual(ROOT.f(1), True)
+
 
 class InitializationTest(unittest.TestCase):
     """Check the initialize method"""

--- a/tests/unit/backend/test_common.py
+++ b/tests/unit/backend/test_common.py
@@ -56,15 +56,17 @@ class IncludeHeadersTest(unittest.TestCase):
 
     def test_string_include(self):
         """'PyRDF.include' with a single string."""
-        PyRDF.include("header1")
+        PyRDF.include("tests/unit/backend/test_headers/header1.hxx")
 
-        self.assertListEqual(PyRDF.includes, ["header1"])
+        required_header = ["tests/unit/backend/test_headers/header1.hxx"]
+        self.assertListEqual(PyRDF.includes, required_header)
 
     def test_list_include(self):
         """'PyRDF.include' with a list of strings."""
-        PyRDF.include(["header1"])
+        PyRDF.include(["tests/unit/backend/test_headers/header1.hxx"])
 
-        self.assertListEqual(PyRDF.includes, ["header1"])
+        required_header = ["tests/unit/backend/test_headers/header1.hxx"]
+        self.assertListEqual(PyRDF.includes, required_header)
 
     def test_list_extend_include(self):
         """
@@ -73,10 +75,11 @@ class IncludeHeadersTest(unittest.TestCase):
         to it multiple times.
 
         """
-        PyRDF.include(["header1", "header2"])
-        PyRDF.include(["header3", "header4", "header5"])
+        PyRDF.include(["tests/unit/backend/test_headers/header1.hxx"])
+        PyRDF.include(["tests/unit/backend/test_headers/header2.hxx"])
 
-        required_list = ["header1", "header2", "header3", "header4", "header5"]
+        required_list = ["tests/unit/backend/test_headers/header1.hxx",
+                         "tests/unit/backend/test_headers/header2.hxx"]
         self.assertListEqual(PyRDF.includes, required_list)
 
 

--- a/tests/unit/backend/test_headers/header3.hxx
+++ b/tests/unit/backend/test_headers/header3.hxx
@@ -1,0 +1,8 @@
+#ifndef HEADER_3
+#define HEADER_3
+
+bool a(int x) {
+	return true;
+}
+
+#endif

--- a/tests/unit/backend/test_headers/header4.hxx
+++ b/tests/unit/backend/test_headers/header4.hxx
@@ -1,0 +1,8 @@
+#ifndef HEADER_4
+#define HEADER_4
+
+bool b(int x) {
+	return true;
+}
+
+#endif


### PR DESCRIPTION
Currently `PyRDF.include('header.h')` stores the headers in a list and declare all of them when the event loop is triggered. This lazy approach is correct, however the header may be also needed on the current running environment, otherwise users need to explicitly declare headers by hand.

To avoid such explicit declaration, this commit modifies `PyRDF.include` to declare each header when the method is called, so that they are also available on the running session.

Recent changes:

- `Initialize` function should not be executed in the `Local` backend, otherwise it runs twice on the running session when `Local` is used as the `current_backend`.
- Headers should not be declared in the `Local` backend for the same reason.
- Use real header files for every test checking header-related methods.
- Introduce new mock header files for testing so each test uses a different header.