### PR TITLE
[WIP] Add support for RDataFrame info operations

### DIFF
--- a/PyRDF/CallableGenerator.py
+++ b/PyRDF/CallableGenerator.py
@@ -33,7 +33,7 @@ class CallableGenerator(object):
             # current PyRDF node as the head node
             node_py = self.head_node
         else:
-            if node_py.operation.is_action() or node_py.operation.is_info() :
+            if node_py.operation.is_action() or node_py.operation.is_info():
                 # Collect all action nodes in order to return them
                 return_nodes.append(node_py)
 

--- a/PyRDF/CallableGenerator.py
+++ b/PyRDF/CallableGenerator.py
@@ -33,7 +33,7 @@ class CallableGenerator(object):
             # current PyRDF node as the head node
             node_py = self.head_node
         else:
-            if node_py.operation.is_action():
+            if node_py.operation.is_action() or node_py.operation.is_info() :
                 # Collect all action nodes in order to return them
                 return_nodes.append(node_py)
 
@@ -96,7 +96,7 @@ class CallableGenerator(object):
                 # recursive call
                 parent_node = pyroot_node
 
-                if node_py.operation.is_action():
+                if node_py.operation.is_action() or node_py.operation.is_info():
                     # Collect all action nodes in order to return them
                     return_vals.append(pyroot_node)
 

--- a/PyRDF/Node.py
+++ b/PyRDF/Node.py
@@ -136,7 +136,7 @@ class Node(object):
         if not self.children:
             # Every pruning condition is written on a separate line
             if not self.has_user_references or \
-                self.is_prunable_action() or self.is_prunable_info():
+               self.is_prunable_action() or self.is_prunable_info():
 
                 # ***** Condition 1 *****
                 # If the node is wrapped by a proxy which is not directly

--- a/PyRDF/Operation.py
+++ b/PyRDF/Operation.py
@@ -32,7 +32,7 @@ class Operation(object):
         print(PyRDF.current_backend.supported_operations)
     """
 
-    Types = Enum("Types", "ACTION TRANSFORMATION INSTANT_ACTION")
+    Types = Enum("Types", "ACTION TRANSFORMATION INSTANT_ACTION INFO")
 
     def __init__(self, name, *args, **kwargs):
         """
@@ -80,7 +80,11 @@ class Operation(object):
             'Take': ops.ACTION,
             'Graph': ops.ACTION,
             'Snapshot': ops.INSTANT_ACTION,
-            'Foreach': ops.INSTANT_ACTION
+            'Foreach': ops.INSTANT_ACTION,
+            'GetColumnNames': ops.INFO,
+            'GetDefinedColumnNames': ops.INFO,
+            'GetColumnType': ops.INFO,
+            'GetFilterNames': ops.INFO,
         }
 
         op_type = operations_dict.get(name)
@@ -107,3 +111,13 @@ class Operation(object):
             False otherwise.
         """
         return self.op_type == Operation.Types.TRANSFORMATION
+
+    def is_info(self):
+        """
+        Checks if the current operation is an info operation.
+
+        Returns:
+            bool: True if the current operation is a transformation,
+            False otherwise.
+        """
+        return self.op_type == Operation.Types.INFO

--- a/PyRDF/Proxy.py
+++ b/PyRDF/Proxy.py
@@ -123,11 +123,10 @@ class TransformationProxy(Proxy):
         Handles an operation call to the current node and returns the new node
         built using the operation call.
         """
+        from PyRDF import current_backend
         # Create a new `Operation` object for the
         # incoming operation call
         op = Operation(self.proxied_node._new_op_name, *args, **kwargs)
-
-        from PyRDF import current_backend
         # Create a new `Node` object to house the operation
         newNode = Node(operation=op, get_head=self.proxied_node.get_head)
 
@@ -137,11 +136,11 @@ class TransformationProxy(Proxy):
         # Return the appropriate proxy object for the node
         if op.is_action():
             return ActionProxy(newNode)
-        elif op.is_transformation() :
+        elif op.is_transformation():
             return TransformationProxy(newNode)
         else:
-            generator = CallableGenerator(self.proxied_node.get_head())
             try:
+                generator = CallableGenerator(self.proxied_node.get_head())
                 current_backend.execute(generator, trigger_loop=False)
             except TypeError as e:
                 self.proxied_node.children.remove(newNode)

--- a/PyRDF/backend/Backend.py
+++ b/PyRDF/backend/Backend.py
@@ -40,6 +40,10 @@ class Backend(ABC):
         'Foreach',
         'Reduce',
         'Aggregate',
+        'GetColumnNames',
+        'GetDefinedColumnNames',
+        'GetColumnType',
+        'GetFilterNames',
         'Graph'
     ]
 
@@ -93,7 +97,7 @@ class Backend(ABC):
             )
 
     @abstractmethod
-    def execute(self, generator):
+    def execute(self, generator, trigger_loop=False):
         """
         Subclasses must define how to run the RDataFrame graph on a given
         environment.

--- a/PyRDF/backend/Dist.py
+++ b/PyRDF/backend/Dist.py
@@ -353,7 +353,7 @@ class Dist(Backend):
 
         return FriendInfo(friend_names, friend_file_names)
 
-    def execute(self, generator):
+    def execute(self, generator, trigger_loop=True):
         """
         Executes the current RDataFrame graph
         in the given distributed environment.
@@ -526,7 +526,7 @@ class Dist(Backend):
             warnings.warn(msg, UserWarning, stacklevel=2)
             PyRDF.use("local")
             from .. import current_backend
-            return current_backend.execute(generator)
+            return current_backend.execute(generator, trigger_loop = True)
 
         # Values produced after Map-Reduce
         values = self.ProcessAndMerge(mapper, reducer)

--- a/PyRDF/backend/Dist.py
+++ b/PyRDF/backend/Dist.py
@@ -526,7 +526,7 @@ class Dist(Backend):
             warnings.warn(msg, UserWarning, stacklevel=2)
             PyRDF.use("local")
             from .. import current_backend
-            return current_backend.execute(generator, trigger_loop = True)
+            return current_backend.execute(generator, trigger_loop=True)
 
         # Values produced after Map-Reduce
         values = self.ProcessAndMerge(mapper, reducer)

--- a/PyRDF/backend/Local.py
+++ b/PyRDF/backend/Local.py
@@ -60,9 +60,6 @@ class Local(Backend):
         # Get the action nodes in the same order as values
         nodes = generator.get_action_nodes()
 
-        print('nodes, ', nodes)
-        print('values, ', values)
-
         for node,value in zip(nodes, values):
             # Set the obtained values and
             # 'RResultPtr's of action nodes

--- a/PyRDF/backend/Local.py
+++ b/PyRDF/backend/Local.py
@@ -60,7 +60,7 @@ class Local(Backend):
         # Get the action nodes in the same order as values
         nodes = generator.get_action_nodes()
 
-        for node,value in zip(nodes, values):
+        for node, value in zip(nodes, values):
             # Set the obtained values and
             # 'RResultPtr's of action nodes
             if trigger_loop and hasattr(value, 'GetValue'):

--- a/tests/integration/local/test_info_operations.py
+++ b/tests/integration/local/test_info_operations.py
@@ -1,0 +1,68 @@
+import unittest
+import PyRDF
+import ROOT
+
+class InfoOperationsLocalTest(unittest.TestCase):
+    """
+    Check that Info operations return the expected result rather than a proxy.
+    """
+
+    def test_GetColumnNames(self):
+        """
+        GetColumnNames returns ROOT string vector without running the event
+        loop.
+        """
+        rdf = PyRDF.RDataFrame(1)
+        d = rdf.Define('a', 'rdfentry_').Define('b', 'a*a')
+
+        column_names = d.GetColumnNames()
+        expected_columns = ROOT.std.vector('string')()
+        expected_columns.push_back("a")
+        expected_columns.push_back("b")
+
+        for column, expected in zip(column_names, expected_columns):
+            self.assertEqual(column, expected)
+
+    def test_GetColumnType(self):
+        """
+        GetColumnType returns the type of a given column as a string.
+        """
+        rdf = PyRDF.RDataFrame(1)
+        d = rdf.Define('a', 'rdfentry_').Define('b', 'a*a')
+
+        a_typename = d.GetColumnType('a')
+        b_typename = d.GetColumnType('b')
+        expected_type = 'ULong64_t'
+
+        self.assertEqual(a_typename, expected_type)
+        self.assertEqual(b_typename, expected_type)
+
+    def test_GetDefinedColumnNames(self):
+        """
+        GetDefinedColumnNames returns the names of the defined columns.
+        """
+        rdf = PyRDF.RDataFrame(1)
+        d = rdf.Define('a', 'rdfentry_').Define('b', 'a*a')
+
+        column_names = d.GetColumnNames()
+        expected_columns = ROOT.std.vector('string')()
+        expected_columns.push_back("a")
+        expected_columns.push_back("b")
+
+        for column, expected in zip(column_names, expected_columns):
+            self.assertEqual(column, expected)
+
+    def test_GetFilterNames(self):
+        """
+        GetFilterNames returns the names of the filters created.
+        """
+        rdf = PyRDF.RDataFrame(1)
+        filter_name = 'custom_filter'
+        d = rdf.Filter('rdfentry_ > 1', filter_name)
+
+        filters = d.GetFilterNames()
+        expected_filters = ROOT.std.vector('string')()
+        expected_filters.push_back(filter_name)
+
+        for f, expected in zip(filters, expected_filters):
+            self.assertEqual(f, expected)

--- a/tests/integration/local/test_info_operations.py
+++ b/tests/integration/local/test_info_operations.py
@@ -2,6 +2,7 @@ import unittest
 import PyRDF
 import ROOT
 
+
 class InfoOperationsLocalTest(unittest.TestCase):
     """
     Check that Info operations return the expected result rather than a proxy.

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -20,6 +20,11 @@ class ClassifyTest(unittest.TestCase):
         op = Operation("Define", "c1")
         self.assertEqual(op.op_type, Operation.Types.TRANSFORMATION)
 
+    def test_info_action(self):
+        """Info nodes are classified accurately."""
+        op = Operation("GetColumnNames")
+        self.assertEqual(op.op_type, Operation.Types.INFO)
+
     def test_none(self):
         """Incorrect operations raise an Exception."""
         with self.assertRaises(Exception):

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -94,6 +94,7 @@ class AttrReadTest(unittest.TestCase):
             "children",
             "_new_op_name",
             "value",
+            "ResultPtr",
             "pyroot_node",
             "has_user_references"
         ]
@@ -145,7 +146,7 @@ class GetValueTests(unittest.TestCase):
         Test backend to verify the working of 'GetValue' instance method
         in Proxy.
         """
-        def execute(self, generator):
+        def execute(self, generator, trigger_loop):
             """
             Test implementation of the execute method
             for 'TestBackend'. This records the head


### PR DESCRIPTION
Allows to call the following operations:

- `GetColumnNames`
- `GetDefinedColumnNames`
- `GetColumnType`
- `GetFilterNames`

This PR adds a new parameter `trigger_loop` to the `execute` method in the `Backend` class. However, we still need to avoid the creation of all the nodes when calling `execute` multiple times.

TO-DO's

- [ ] Avoid duplicated nodes
- [ ] Define operations in one single place, now they are duplicated (maybe a different PR)
- [ ] Add as non-supported operations in Spark. 