### PR TITLE
Send the rest of the args to Snapshot using spark backend

### DIFF
--- a/PyRDF/CallableGenerator.py
+++ b/PyRDF/CallableGenerator.py
@@ -102,7 +102,7 @@ class CallableGenerator(object):
                     path_with_range = "{}_{}_{}.root".format(filename,
                                                              start, end)
                     # Create a partial snapshot on the current range
-                    operations.args[1] = path_with_range
+                    operation.args[1] = path_with_range
                 pyroot_node = RDFOperation(*operation.args,
                                            **operation.kwargs)
 

--- a/PyRDF/CallableGenerator.py
+++ b/PyRDF/CallableGenerator.py
@@ -103,7 +103,8 @@ class CallableGenerator(object):
                                                              start, end)
                     # Create a partial snapshot on the current range
                     pyroot_node = RDFOperation(operation.args[0],
-                                               path_with_range)
+                                               path_with_range,
+                                               *operation.args[2:])
                 else:
                     pyroot_node = RDFOperation(*operation.args,
                                                **operation.kwargs)

--- a/PyRDF/CallableGenerator.py
+++ b/PyRDF/CallableGenerator.py
@@ -102,12 +102,9 @@ class CallableGenerator(object):
                     path_with_range = "{}_{}_{}.root".format(filename,
                                                              start, end)
                     # Create a partial snapshot on the current range
-                    pyroot_node = RDFOperation(operation.args[0],
-                                               path_with_range,
-                                               *operation.args[2:])
-                else:
-                    pyroot_node = RDFOperation(*operation.args,
-                                               **operation.kwargs)
+                    operations.args[1] = path_with_range
+                pyroot_node = RDFOperation(*operation.args,
+                                           **operation.kwargs)
 
                 # The result is a pyroot object which is stored together with
                 # the pyrdf node. This binds the pyroot object lifetime to the

--- a/PyRDF/Operation.py
+++ b/PyRDF/Operation.py
@@ -48,7 +48,7 @@ class Operation(object):
         kwargs (dict): Keyword arguments for the current operation.
         """
         self.name = name
-        self.args = args
+        self.args = list(args)
         self.kwargs = kwargs
         self.op_type = self._classify_operation(name)
 

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -282,7 +282,7 @@ class DunderMethodsTest(unittest.TestCase):
         node_dict = {"children": [n1.proxied_node]}
         n1_dict = {
             'operation_name': "Define",
-            'operation_args': ("a",),
+            'operation_args': ["a",],
             'operation_kwargs': {"b": "c"},
             'children': []
         }
@@ -304,7 +304,7 @@ class DunderMethodsTest(unittest.TestCase):
         node_dict = {"children": [n1]}
         n1_dict = {
             'operation_name': "Define",
-            'operation_args': ("a",),
+            'operation_args': ["a",],
             'operation_kwargs': {"b": "c"},
             'children': []
         }

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -19,7 +19,7 @@ class OperationReadTest(unittest.TestCase):
         """Arguments (unnamed) are read accurately."""
         node = TransformationProxy(Node(None, None))
         newNode = node.Define(1, "b", a="1", b=2)
-        self.assertEqual(newNode.operation.args, (1, "b"))
+        self.assertEqual(newNode.operation.args, [1, "b"])
 
     def test_kwargs_read(self):
         """Named arguments are read accurately."""

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -282,7 +282,7 @@ class DunderMethodsTest(unittest.TestCase):
         node_dict = {"children": [n1.proxied_node]}
         n1_dict = {
             'operation_name': "Define",
-            'operation_args': ["a",],
+            'operation_args': ["a"],
             'operation_kwargs': {"b": "c"},
             'children': []
         }
@@ -304,7 +304,7 @@ class DunderMethodsTest(unittest.TestCase):
         node_dict = {"children": [n1]}
         n1_dict = {
             'operation_name': "Define",
-            'operation_args': ["a",],
+            'operation_args': ["a"],
             'operation_kwargs': {"b": "c"},
             'children': []
         }

--- a/tests/unit/test_operation.py
+++ b/tests/unit/test_operation.py
@@ -32,23 +32,23 @@ class ArgsTest(unittest.TestCase):
     def test_without_kwargs(self):
         """Check that unnamed arguments are properly set."""
         op = Operation("Define", 1, "b")
-        self.assertEqual(op.args, (1, "b"))
+        self.assertEqual(op.args, [1, "b"])
         self.assertEqual(op.kwargs, {})
 
     def test_without_args(self):
         """Check that no unnamed arguments are properly set."""
         op = Operation("Define", a=1, b="b")
-        self.assertEqual(op.args, ())
+        self.assertEqual(op.args, [])
         self.assertEqual(op.kwargs, {"a": 1, "b": "b"})
 
     def test_with_args_and_kwargs(self):
         """Check that named and unnamed arguments are properly set."""
         op = Operation("Define", 2, "p", a=1, b="b")
-        self.assertEqual(op.args, (2, "p"))
+        self.assertEqual(op.args, [2, "p"])
         self.assertEqual(op.kwargs, {"a": 1, "b": "b"})
 
     def test_without_args_and_kwargs(self):
         """Check Operation constructor without arguments."""
         op = Operation("Define")
-        self.assertEqual(op.args, ())
+        self.assertEqual(op.args, [])
         self.assertEqual(op.kwargs, {})

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -67,9 +67,9 @@ class AttrReadTest(unittest.TestCase):
         proxy = TransformationProxy(node)
 
         transformations = {
-            "Define": ("x", "tdfentry_"),
-            "Filter": ("tdfentry_ > 0",),
-            "Range": ("tdfentry_",)
+            "Define": ["x", "tdfentry_"],
+            "Filter": ["tdfentry_ > 0"],
+            "Range": ["tdfentry_"]
         }
 
         for transformation, args in transformations.items():


### PR DESCRIPTION
Thanks for the interesting project, I have a small issue that I fixed:

Currently, the spark backend doesn't have the ability to store only select branches since it drops the branch vector arguments from Snapshot. This is not so nice when trying to run a big skim, since we end up writing more data than we should. This is a minimal fix for that, by passing the rest of the arguments through to the operation.
