### PR TITLE
Avoid changing class name to results of `AsNumpy`

### DIFF
--- a/PyRDF/backend/Dist.py
+++ b/PyRDF/backend/Dist.py
@@ -462,13 +462,7 @@ class Dist(Backend):
             for i in range(len(output)):
                 # `AsNumpy` and `Snapshot` return respectively `dict` and `list`
                 # that don't have the `GetValue` method.
-                if isinstance(output[i], dict):
-                    # Fix class name to 'ndarray' to avoid issues with
-                    # Pickle protocol 2
-                    for value in output[i].values():
-                        value.__class__.__name__ = "ndarray"
-                    continue
-                if isinstance(output[i], list):
+                if isinstance(output[i], (dict, list)):
                     continue
                 # FIX ME : RResultPtrs aren't serializable,
                 # because of which we have to manually find


### PR DESCRIPTION
https://github.com/root-project/root/pull/4197 fixes a bug in PyROOT that was conflicting with pickle (protocol 2).
The special condition for `AsNumpy` in the mapper of the distributed backend can be thus deleted.