### PR TITLE
RunGraphs: Trigger the execution of multiple graphs

### DIFF
--- a/PyRDF/backend/Local.py
+++ b/PyRDF/backend/Local.py
@@ -82,3 +82,11 @@ class Local(Backend):
                 # those should be in scope while doing
                 # a 'GetValue' call on them
                 nodes[i].ResultPtr = values[i]
+
+    @staticmethod
+    def RunGraphs(proxies, concurrent_runs=4):
+        """
+        Trigger the execution of multiple RDataFrame computation graphs. Not
+        implemented in the Local backend.
+        """
+        raise NotImplementedError

--- a/tests/unit/backend/test_local.py
+++ b/tests/unit/backend/test_local.py
@@ -88,3 +88,12 @@ class InitializationTest(unittest.TestCase):
         df = PyRDF.RDataFrame(1)
         s = df.Define("userValue", "getUserValue()").Sum("userValue")
         self.assertEqual(s.GetValue(), 123)
+
+
+class MiscTest(unittest.TestCase):
+    """Miscellaneous tests for Local backend."""
+
+    def test_rungraphs_notimplemented(self):
+        """Check that RunGraphs is not implemented"""
+        with self.assertRaises(NotImplementedError):
+            Local.RunGraphs([PyRDF.RDataFrame(10).Count() for _ in range(4)])

--- a/tests/unit/backend/test_spark.py
+++ b/tests/unit/backend/test_spark.py
@@ -1,7 +1,11 @@
+import array
+import os
 import unittest
+
 import PyRDF
-from PyRDF.backend.Spark import Spark
+import ROOT
 from PyRDF.backend.Local import Local
+from PyRDF.backend.Spark import Spark
 from pyspark import SparkContext
 
 


### PR DESCRIPTION
The new `run_graphs` function is inspired by the logic of [ROOT::RDF::RunGraphs](https://github.com/root-project/root/blob/f8efb11a51cbe5b5152ebef19a4f7b78744ca2fa/tree/dataframe/src/RDFHelpers.cxx#L23). Its main use for now is to trigger the execution of multiple Spark jobs concurrently, each job is submitted in a different thread as suggested by the [Spark docs](https://spark.apache.org/docs/latest/job-scheduling.html#scheduling-within-an-application).

This implementation is open to suggestions, as are also the name of the function and the place it should belong to in PyRDF. A first test is added to check that the functionality works